### PR TITLE
Show only one priority on a work order page

### DIFF
--- a/app/views/work_orders/_work_order_reference_top_section.html.erb
+++ b/app/views/work_orders/_work_order_reference_top_section.html.erb
@@ -79,12 +79,14 @@
               </td>
             </tr>
 
-            <tr>
-              <th scope="row">Priority:</th>
-              <td>
-                <%= @work_order.repair_request.priority %>
-              </td>
-            </tr>
+            <% unless @work_order.latest_appointment.present? %>
+              <tr>
+                <th scope="row">Priority:</th>
+                <td>
+                  <%= @work_order.repair_request.priority %>
+                </td>
+              </tr>
+            <% end %>
           </tbody>
         </table>
 


### PR DESCRIPTION
After a user testing session, it turns out that two priorities on a work order page are a bit confusing.

That's why we'll display only one priority. 

If there is the latest appointment, we'll display LA's priority (LHO request), but if it's empty - work order's priority.