### PR TITLE
fix bug where using filters affects possibly related work orders

### DIFF
--- a/app/views/work_orders/_repair_history_filters.html.erb
+++ b/app/views/work_orders/_repair_history_filters.html.erb
@@ -58,7 +58,7 @@
 
     function handleToggleTrade() {
       filterCheckBoxes = document.querySelectorAll('.trade-filter-checkbox:checked');
-      workOrders = document.querySelectorAll('.hackney-work-order-rows');
+      workOrders = document.querySelectorAll('.hackney-work-order-rows.repairs-history');
 
       var showTheseTrades = [];
 

--- a/app/views/work_orders/_work_order_repairs_history.html.erb
+++ b/app/views/work_orders/_work_order_repairs_history.html.erb
@@ -23,7 +23,7 @@
             </thead>
             <tbody class="govuk-table__body">
             <% work_orders.sort_by(&:created).reverse.each do |work_order| %>
-              <tr class="govuk-table__row hackney-work-order-rows"
+              <tr class="govuk-table__row hackney-work-order-rows repairs-history"
                   data-trade="trade-<%= trades.index(work_order.trade) %>">
                 <td class="govuk-table__cell"><%= link_to work_order.reference, work_order_path(work_order.reference) %></td>
                 <td class="govuk-table__cell hackney-work-order-date-raised">


### PR DESCRIPTION
Using the trade filter would also impact on the possibly related work orders. For example if you selected anything other than Plumbing i.e Electrical then none of the plumbing work orders show up on possibly related due to sharing same class for JS query selector.