### PR TITLE
Fix for possibly related if work order relates to estate

### DIFF
--- a/app/views/work_orders/_work_order_possibly_related.html.erb
+++ b/app/views/work_orders/_work_order_possibly_related.html.erb
@@ -11,10 +11,12 @@
 </div>
 
 <script>
-  window.addEventListener("load", function() {
-    var endpoint = "/api/properties/<%= property.reference %>/possibly_related_work_orders";
-    var ajaxTab = document.getElementById('possibly-related-work-orders');
+  if (!document.getElementById('possibly-related-estate')) {
+    window.addEventListener("load", function() {
+      var endpoint = "/api/properties/<%= property.reference %>/possibly_related_work_orders";
+      var ajaxTab = document.getElementById('possibly-related-work-orders');
 
-    handleAjaxResponse(endpoint, ajaxTab);
-  });
+      handleAjaxResponse(endpoint, ajaxTab);
+    });
+  }
 </script>


### PR DESCRIPTION
Following the Javascript changes, the functionality which said that possibly related work orders for an estate was lost. This adds it back again.