### PR TITLE
Stop 'possibly related' making an extra api call

### DIFF
--- a/app/views/api/properties/possibly_related_work_orders.html.erb
+++ b/app/views/api/properties/possibly_related_work_orders.html.erb
@@ -1,38 +1,42 @@
 <h2 class='govuk-heading-l'>
   Possibly related
 </h2>
-<% if @property.work_orders_plumbing_from_block_and_last_two_weeks.present? %>
-  <p class="govuk-caption-m">Possibly related plumbing work orders from last two weeks.</p>
-
-  <table class="govuk-table hackney-work-order-table">
-    <thead class="govuk-table__head">
-    <tr>
-      <th class="govuk-table__header" scope="col">Reference</th>
-      <th class="govuk-table__header" scope="col">Date raised</th>
-      <th class="govuk-table__header" scope="col">Status</th>
-      <th class="govuk-table__header" scope="col">Trade</th>
-      <th class="govuk-table__header" scope="col">Description</th>
-    </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-    <% @property.work_orders_plumbing_from_block_and_last_two_weeks.sort_by(&:created).reverse.each do |work_order| %>
-      <tr class="govuk-table__row hackney-work-order-rows">
-        <td class="govuk-table__cell"><%= link_to work_order.reference, work_order_path(work_order.reference) %></td>
-        <td class="govuk-table__cell hackney-work-order-date-raised--left">
-          <p class='work_order_date_created'><%= work_order.created.to_date.to_s(:govuk_date_short) %></p>
-          <p class='govuk-body-s work_order_time_created'><%= work_order.created.to_s(:govuk_time) %></p>
-        </td>
-        <td class="govuk-table__cell">
-          <span class="govuk-body-s status status-<%= work_order.work_order_status %>">
-            <%= work_order_status_description(work_order.work_order_status).capitalize %>
-          </span>
-        </td>
-        <td class="govuk-table__cell description work-order-trade"><%= work_order.trade %></td>
-        <td class="govuk-table__cell description"><%= work_order.problem_description %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
+<% if @property.is_estate? %>
+  <p class="govuk-body-s" id="possibly-related-estate">Possibly related records relating to an estate are unavailable.</p>
 <% else %>
-  <p class="govuk-body-s">There are no possibly related plumbing work orders from last two weeks.</p>
+  <% if @property.work_orders_plumbing_from_block_and_last_two_weeks.present? %>
+    <p class="govuk-caption-m">Possibly related plumbing work orders from last two weeks.</p>
+
+    <table class="govuk-table hackney-work-order-table">
+      <thead class="govuk-table__head">
+      <tr>
+        <th class="govuk-table__header" scope="col">Reference</th>
+        <th class="govuk-table__header" scope="col">Date raised</th>
+        <th class="govuk-table__header" scope="col">Status</th>
+        <th class="govuk-table__header" scope="col">Trade</th>
+        <th class="govuk-table__header" scope="col">Description</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @property.work_orders_plumbing_from_block_and_last_two_weeks.sort_by(&:created).reverse.each do |work_order| %>
+        <tr class="govuk-table__row hackney-work-order-rows">
+          <td class="govuk-table__cell"><%= link_to work_order.reference, work_order_path(work_order.reference) %></td>
+          <td class="govuk-table__cell hackney-work-order-date-raised--left">
+            <p class='work_order_date_created'><%= work_order.created.to_date.to_s(:govuk_date_short) %></p>
+            <p class='govuk-body-s work_order_time_created'><%= work_order.created.to_s(:govuk_time) %></p>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="govuk-body-s status status-<%= work_order.work_order_status %>">
+              <%= work_order_status_description(work_order.work_order_status).capitalize %>
+            </span>
+          </td>
+          <td class="govuk-table__cell description work-order-trade"><%= work_order.trade %></td>
+          <td class="govuk-table__cell description"><%= work_order.problem_description %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="govuk-body-s">There are no possibly related plumbing work orders from last two weeks.</p>
+  <% end %>
 <% end %>

--- a/app/views/work_orders/_work_order_possibly_related.html.erb
+++ b/app/views/work_orders/_work_order_possibly_related.html.erb
@@ -1,22 +1,12 @@
 <div class="govuk-tabs__panel hackney-work-order-tabs-info" id="possibly-related-work-orders">
-  <% if property.is_estate? %>
-    <h2 class='govuk-heading-l'>
-    Possibly related
-    </h2>
-
-    <p class="govuk-body-s" id="possibly-related-estate">Possibly related records relating to an estate are unavailable.</p>
-  <% else %>
-    <p class="govuk-caption-m ajax-loading">Loading possibly related work orders data</p>
-  <% end %>
+  <p class="govuk-caption-m ajax-loading">Loading possibly related work orders data</p>
 </div>
 
 <script>
-  if (!document.getElementById('possibly-related-estate')) {
-    window.addEventListener("load", function() {
-      var endpoint = "/api/properties/<%= property.reference %>/possibly_related_work_orders";
-      var ajaxTab = document.getElementById('possibly-related-work-orders');
+  window.addEventListener("load", function() {
+    var endpoint = "/api/properties/<%= property.reference %>/possibly_related_work_orders";
+    var ajaxTab = document.getElementById('possibly-related-work-orders');
 
-      handleAjaxResponse(endpoint, ajaxTab);
-    });
-  }
+    handleAjaxResponse(endpoint, ajaxTab);
+  });
 </script>

--- a/spec/features/work_order_spec.rb
+++ b/spec/features/work_order_spec.rb
@@ -286,15 +286,14 @@ RSpec.describe 'Work order' do
     expect(page).to have_content "2:10pm, 29 May 2018"
   end
 
-  scenario 'The property is an estate' do
+  scenario 'The property is an estate', js: true do
     stub_hackney_work_orders_for_property(reference: property_reference2, body: work_orders_by_property_reference_payload__different_property)
     stub_hackney_property_hierarchy(body: property_hierarchy_response_body__estate)
 
     visit work_order_path('01551932')
 
-    within(find('h2', text: 'Possibly related').find(:xpath, '..')) do
-      expect(page).to have_content 'Possibly related records relating to an estate are unavailable.'
-    end
+    click_on('Possibly related')
+    expect(page).to have_content 'Possibly related records relating to an estate are unavailable.'
   end
 
   scenario 'There are no reports for a work order', js: true do


### PR DESCRIPTION
Possibly related was making an api call to check whether the property was an estate before it was ajaxed in.

This call is now made in ajax.