### PR TITLE
Don't retry when an error occurs in the feed

### DIFF
--- a/app/jobs/notes_feed_job.rb
+++ b/app/jobs/notes_feed_job.rb
@@ -16,6 +16,9 @@ class NotesFeedJob < ApplicationJob
     if enqueues < max_enqueues && notes.size >= ENQUEUE_LIMIT
       NotesFeedJob.perform_later(enqueues + 1, max_enqueues)
     end
+
+  rescue StandardError => e
+    Appsignal.set_error(e)
   end
 
   private

--- a/app/jobs/work_order_feed_job.rb
+++ b/app/jobs/work_order_feed_job.rb
@@ -29,6 +29,9 @@ class WorkOrderFeedJob < ApplicationJob
     if execution < max_executions && work_orders.size >= EXECUTION_LIMIT
       perform(execution + 1, max_executions)
     end
+
+  rescue StandardError => e
+    Appsignal.set_error(e)
   end
 
   private

--- a/spec/jobs/notes_feed_job_spec.rb
+++ b/spec/jobs/notes_feed_job_spec.rb
@@ -97,4 +97,11 @@ RSpec.describe NotesFeedJob, :db_connection, type: :job do
     }.to_not raise_error
   end
 
+  it "rescues errors and sends them to appsignal" do
+    error = StandardError.new('BOOOM!')
+    expect(Hackney::Note).to receive(:feed) { raise error }
+    expect(Appsignal).to receive(:set_error).with(error)
+
+    NotesFeedJob.perform_now(1, 1)
+  end
 end

--- a/spec/jobs/work_order_feed_job_spec.rb
+++ b/spec/jobs/work_order_feed_job_spec.rb
@@ -41,4 +41,12 @@ RSpec.describe WorkOrderFeedJob, :db_connection, type: :job do
     expect(Graph::WorkOrder.count).to eq 50
     expect(Graph::LastFromFeed.last_work_order.last_id).to eq fifty_work_orders.last.reference
   end
+
+  it "rescues errors and sends them to appsignal" do
+    error = StandardError.new('BOOOM!')
+    expect(Hackney::WorkOrder).to receive(:feed) { raise error }
+    expect(Appsignal).to receive(:set_error).with(error)
+
+    WorkOrderFeedJob.perform_now(1, 1)
+  end
 end


### PR DESCRIPTION
More jobs will be created by the scheduler anyway and we don't want to
overwhelm the API in the event that they turn it off for a while and
then get flooded by a whole lot of queued jobs.