### PR TITLE
Use property model to load the hierarchy and cache it

### DIFF
--- a/app/services/hackney/work_orders/associated_with_property.rb
+++ b/app/services/hackney/work_orders/associated_with_property.rb
@@ -3,10 +3,8 @@ module Hackney
     class AssociatedWithProperty
       HIERARCHY_DESCRIPTIONS = %w(Estate Block Sub-Block Free Facilities Dwelling Non-Dwell).freeze
 
-      attr_reader :reference
-
-      def initialize(reference)
-        @reference = reference
+      def initialize(property)
+        @property = property
       end
 
       def call
@@ -21,9 +19,11 @@ module Hackney
         end
 
         data.delete_if { |_, value|  value.empty? }
-    end
+      end
 
       private
+
+      attr_accessor :property
 
       def fetch_work_orders(property_references)
         Hackney::WorkOrder.for_property(property_references: property_references,
@@ -32,7 +32,7 @@ module Hackney
       end
 
       def filtered_hierarchy
-        Hackney::Property.hierarchy(reference).each_with_object({}) do |element, hash|
+        property.hierarchy.each_with_object({}) do |element, hash|
           hash[element.reference] = element.description if element.description.in?(HIERARCHY_DESCRIPTIONS)
         end
       end

--- a/spec/models/hackney/property_spec.rb
+++ b/spec/models/hackney/property_spec.rb
@@ -59,7 +59,7 @@ describe Hackney::Property, '.dwelling_work_orders_hierarchy' do
   let(:associated_with_property_double) { instance_double(Hackney::WorkOrders::AssociatedWithProperty, call: result) }
 
   before do
-    allow(Hackney::WorkOrders::AssociatedWithProperty).to receive(:new).with(reference).and_return(associated_with_property_double)
+    allow(Hackney::WorkOrders::AssociatedWithProperty).to receive(:new).with(klass_instance).and_return(associated_with_property_double)
   end
 
   subject { klass_instance.dwelling_work_orders_hierarchy }
@@ -89,8 +89,7 @@ describe Hackney::Property, '#work_orders_plumbing_from_block_and_last_two_weeks
 end
 
 describe Hackney::Property do
-  describe '.hierarchy' do
-    let(:property) { 11111 }
+  describe '#hierarchy' do
     let(:hierarchy_object) do
       {
         'propertyReference' => '1',
@@ -108,12 +107,13 @@ describe Hackney::Property do
       allow(HackneyAPI::RepairsClient).to receive(:new).and_return(repairs_client_double)
     end
 
-    subject { described_class.hierarchy(property) }
+    subject { build :property, reference: 11111 }
 
     it 'returns an array with instances of Hackney::Property built based on an API response' do
-      expect(repairs_client_double).to receive(:get_property_hierarchy).with(property)
+      expect(repairs_client_double).to receive(:get_property_hierarchy).with(subject.reference)
       expect(described_class).to receive(:build).once
-      subject
+
+      subject.hierarchy
     end
   end
 

--- a/spec/services/hackney/work_orders/associated_with_property_spec.rb
+++ b/spec/services/hackney/work_orders/associated_with_property_spec.rb
@@ -4,9 +4,9 @@ describe Hackney::WorkOrders::AssociatedWithProperty do
   include Helpers::HackneyRepairsRequestStubs
 
   describe '#call' do
-    let(:dwelling_reference) { 1 }
+    let(:property) { build :property }
 
-    let(:service_instance) { described_class.new(dwelling_reference) }
+    let(:service_instance) { described_class.new(property) }
     let(:property_hierarchy_estate) { build(:property, description: 'Estate') }
     let(:property_hierarchy_free) { build(:property, description: 'Free') }
     let(:property_hierarchy_block) { build(:property, description: 'Block') }
@@ -51,7 +51,7 @@ describe Hackney::WorkOrders::AssociatedWithProperty do
     end
 
     before do
-      allow(Hackney::Property).to receive(:hierarchy).with(dwelling_reference).and_return(property_hierarchy_response)
+      allow(property).to receive(:hierarchy).and_return(property_hierarchy_response)
     end
 
     subject { service_instance.call }


### PR DESCRIPTION
This lets us write is_estate? with the cached values. We were getting
multiple calls to the api because we were using associated_with_property
to determine if a property was an estate.

This alose lets us pass models rather than references - which is normally
better.