### PR TITLE
use an cache object to reduce the number of property api calls

### DIFF
--- a/app/controllers/api/properties_controller.rb
+++ b/app/controllers/api/properties_controller.rb
@@ -2,7 +2,10 @@ module Api
   class PropertiesController < Api::ApiController
     def possibly_related_work_orders
       @property = Hackney::Property.find(reference)
-      @address_map = build_address_map(@property)
+
+      @address_cache = Cache.new(@property.reference => @property.address) do |prop_ref|
+        Hackney::Property.find(prop_ref).address
+      end
     end
 
     def repairs_history
@@ -13,15 +16,6 @@ module Api
 
     def reference
       params[:ref]
-    end
-
-    # Pre fetch addresses for all the work orders rather than delegate down to
-    # the work order to avoid fetching the property multiple times
-    def build_address_map(property)
-      property.work_orders_plumbing_from_block_and_last_two_weeks
-              .each_with_object({ property.reference => property.address }) do |work_order, map|
-        map[work_order.prop_ref] ||= work_order.property.address
-      end
     end
   end
 end

--- a/app/services/cache.rb
+++ b/app/services/cache.rb
@@ -1,0 +1,14 @@
+class Cache
+  def initialize(initial_data = {}, &block)
+    @block = block
+    @data = initial_data
+  end
+
+  def [](key)
+    data[key] ||= block.call key
+  end
+
+  private
+
+  attr_accessor :data, :block
+end

--- a/app/views/api/properties/possibly_related_work_orders.html.erb
+++ b/app/views/api/properties/possibly_related_work_orders.html.erb
@@ -26,8 +26,8 @@
             <p class='work_order_date_created'><%= work_order.created.to_date.to_s(:govuk_date_short) %></p>
             <p class='govuk-body-s work_order_time_created'><%= work_order.created.to_s(:govuk_time) %></p>
           </td>
-          <td class="govuk-table__cell" title="<%= @address_map[work_order.prop_ref] %>">
-            <% @address_map[work_order.prop_ref].split('  ').each do |line| %>
+          <td class="govuk-table__cell" title="<%= @address_cache[work_order.prop_ref] %>">
+            <% @address_cache[work_order.prop_ref].split('  ').each do |line| %>
               <p class="address"><%= line %></p>
             <% end %>
           </td>

--- a/spec/features/work_order_spec.rb
+++ b/spec/features/work_order_spec.rb
@@ -292,6 +292,10 @@ RSpec.describe 'Work order' do
   scenario 'The property is an estate', js: true do
     stub_hackney_work_orders_for_property(reference: property_reference2, body: work_orders_by_property_reference_payload__different_property)
     stub_hackney_property_hierarchy(body: property_hierarchy_response_body__estate)
+    stub_hackney_repairs_work_order_block_by_trade(status: 403, body: {
+      "developerMessage"=>"Exception of type 'HackneyRepairs.Actions.InvalidParameterException' was thrown.",
+      "userMessage"=>"403 Forbidden - Invalid parameter provided."
+    })
 
     visit work_order_path('01551932')
 

--- a/spec/services/cache_spec.rb
+++ b/spec/services/cache_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Cache do
+  it 'returns a cached value' do
+    api = double
+    expect(api).to receive(:fetch).once { 'woo!' }
+
+    cache = Cache.new { |k| api.fetch(k) }
+
+    expect(cache['a']).to eq 'woo!'
+    expect(cache['a']).to eq 'woo!'
+  end
+
+  it 'returns seeded values' do
+    api = double
+    expect(api).to receive(:fetch).never
+
+    cache = Cache.new('b' => 'boo!') { |k| api.fetch(k) }
+
+    expect(cache['b']).to eq 'boo!'
+  end
+end


### PR DESCRIPTION
We need a separate object becuase we want to delay the call because the view
controls the logic of whether to call the api or not.