### PR TITLE
sorting by property ref on api side so no need to sort on front end

### DIFF
--- a/app/views/properties/_address_list.html.erb
+++ b/app/views/properties/_address_list.html.erb
@@ -14,7 +14,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% address_list.sort_by(&:address).each do |property| %>
+        <% address_list.each do |property| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= link_to property.address, property_path(property.reference) %></td>
           <td class="govuk-table__cell"><%= property.postcode %></td>


### PR DESCRIPTION
Properties have been sorted on the API side so we will show the response given back with no added sorting on the front end.