### PR TITLE
govuk-button :active & :hover

### DIFF
--- a/app/assets/stylesheets/hackney_button.scss
+++ b/app/assets/stylesheets/hackney_button.scss
@@ -1,21 +1,26 @@
 .govuk-button {
   background-color: hackney-colour('housing-2');
-   &:hover {
+  &:hover {
     background-color: #10767c;
   }
-   &:disabled {
+  &:disabled {
     opacity: 0.3;
   }
 }
- .govuk-button[disabled="disabled"],
+
+.govuk-button[disabled="disabled"],
 .govuk-button[disabled] {
   opacity: (.5);
   background: hackney-colour('housing-2');
-   &:hover {
+  &:hover {
     background-color: hackney-colour('housing-2');
     cursor: default;
   }
-   &:focus {
+  &:focus {
     outline: none;
+    background-color: hackney-colour('housing-2') !important;
   }
+}
+.govuk-button:hover, .govuk-button:focus {
+  background-color: hackney-colour('housing-2') !important;
 }


### PR DESCRIPTION
2 changes:

1) Correct the indentation

2) Overwrite the govuk `:hover` and `:focus ` attributes from its default colour to match our current colour theme. It appears that this can only be done by increasing the specificity by using `!important`.