### PR TITLE
govuk-button :active

### DIFF
--- a/app/assets/stylesheets/hackney_button.scss
+++ b/app/assets/stylesheets/hackney_button.scss
@@ -1,21 +1,25 @@
 .govuk-button {
   background-color: hackney-colour('housing-2');
-   &:hover {
+  &:hover {
     background-color: #10767c;
   }
-   &:disabled {
+  &:disabled {
     opacity: 0.3;
   }
+  &:focus {
+    background-color: hackney-colour('housing-2');
+  }
 }
- .govuk-button[disabled="disabled"],
+
+.govuk-button[disabled="disabled"],
 .govuk-button[disabled] {
   opacity: (.5);
   background: hackney-colour('housing-2');
-   &:hover {
+  &:hover {
     background-color: hackney-colour('housing-2');
     cursor: default;
   }
-   &:focus {
+  &:focus {
     outline: none;
   }
 }


### PR DESCRIPTION
2 changes:

1) Correct the indentation

2) Overwrite the govuk `:focus` attribute from its default colour to match our current colour theme