### PR TITLE
Adjust tab behaviour on smaller devices

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,3 +18,8 @@
 //= require building-type-filter
 //= require disable-link-after-click
 //= require_tree .
+
+// This disables govuk tab behaviour. On a mobile device the tab content now remain in separate tabs, rather than
+// being on one long page.
+Tabs.prototype.setupResponsiveChecks = function () {
+};

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,10 +69,7 @@ $govuk-breakpoints: (
   background-color: govuk-colour("grey-4");
   border-bottom: 1px solid govuk-colour("grey-2");
   padding-top: 10px;
-
-  @media (min-width: 641px) {
-    padding-bottom: 50px;
-  }
+  padding-bottom: 30px;
 }
 
 .hackney-width-container {
@@ -127,10 +124,8 @@ $govuk-breakpoints: (
 
 // govuk styling specifies this as ems, and the other as pixels,
 // so need to overwrite it directly
-@media (min-width: 40.0625em) {
-  .govuk-width-container {
-    margin: 0 ($govuk-gutter / 6);
-  }
+.govuk-width-container {
+  margin: 0 ($govuk-gutter / 6);
 }
 
 @media (min-width: 1260px) {


### PR DESCRIPTION
Deleted some css which affected behaviour on smaller devices. Page should just get smaller now. And tabs act as tabs, rather than listing content on one long page.