### PR TITLE
Quick fix for Notes feed job

### DIFF
--- a/app/models/graph/note.rb
+++ b/app/models/graph/note.rb
@@ -14,9 +14,13 @@ class Graph::Note
   end
 
   FIRST_NOTE_ID = 1
+  LAST_NOTE_HACK = 9_000_000
 
   def self.last_note_id
-    last_note = self.last
+    scope = self.query_as(:z).order("z.note_id DESC").limit(1)
+
+    last_note = scope.where("z.note_id > #{LAST_NOTE_HACK}").pluck(:z).first
+    last_note ||= scope.pluck(:z).first
     last_note.nil? ? FIRST_NOTE_ID : last_note.note_id
   end
 end

--- a/spec/models/graph/note_spec.rb
+++ b/spec/models/graph/note_spec.rb
@@ -6,4 +6,17 @@ describe Graph::Note, :db_connection do
 
     expect(Graph::Note.first.id).to eq 1
   end
+
+  it 'gets the last note id' do
+    Graph::Note.create!(note_id: 8_999_999, source: 'test', logged_at: Time.current, work_order_reference: '0' * 8)
+    Graph::Note.create!(note_id: 9_000_001, source: 'test', logged_at: Time.current, work_order_reference: '0' * 8)
+
+    expect(Graph::Note.last_note_id).to eq 9_000_001
+  end
+
+  it 'returns the last note id when there are less than 9 million records' do
+    Graph::Note.create!(note_id: 8_999_999, source: 'test', logged_at: Time.current, work_order_reference: '0' * 8)
+
+    expect(Graph::Note.last_note_id).to eq 8_999_999
+  end
 end


### PR DESCRIPTION
Hack round getting the last note id because Graph::Note.last was very slow, because it's doing a table scan. We've made it faster by only looking at records with an id greater than 9 million