### PR TITLE
Add note-id to the html output to help determine why things are related

### DIFF
--- a/app/views/work_orders/_note.html.erb
+++ b/app/views/work_orders/_note.html.erb
@@ -1,4 +1,4 @@
-<div class="hackney-note-info">
+<div class="hackney-note-info" data-note-id="<%= note_or_appointment.note_id %>">
   <%= note_or_appointment.logged_at.to_s(:govuk_date_time) %> by <%= note_or_appointment.logged_by %>
 </div>
 <%= simple_format(note_or_appointment.text) %>

--- a/spec/features/work_order_spec.rb
+++ b/spec/features/work_order_spec.rb
@@ -93,8 +93,10 @@ RSpec.describe 'Work order' do
     end
 
     click_on('Notes and appointments')
-    expect(page).to have_content "2 September 2018, 11:32am by Servitor\nFurther works required; Tiler required to renew splash back and reseal bath"
-    expect(page).to have_content "23 August 2018, 10:12am by MOSHEA\nTenant called to confirm appointment"
+    expect(find('div[data-note-id="4000"]')).to have_content '2 September 2018, 11:32am by Servitor'
+    expect(find('div[data-note-id="4000"]+p')).to have_content 'Further works required; Tiler required to renew splash back and reseal bath'
+    expect(find('div[data-note-id="3000"]')).to have_content '23 August 2018, 10:12am by MOSHEA'
+    expect(find('div[data-note-id="3000"]+p')).to have_content 'Tenant called to confirm appointment'
     expect(page).to have_content "30 May 2018, 8:00am-12:00pm\nAppointment: Planned\nOperative name: (PLM) Fatima Bagam TEST\nPhone number:\nCreated: 29 May 2018, 2:10pm\nData source: DRS"
     expect(page).to have_content "29 May 2018, 2:51pm to 5 June 2018, 2:51pm\nAppointment: Planned\nOperative name: (PLM) Brian Liverpool\nPhone number: +447535847993\nCreated: 29 May 2018, 2:51pm\nData source: DRS"
     expect(page).to have_content "17 October 2017, 9:27am to 24 October 2017, 9:27am\nAppointment: Completed\nOperative name: (PLM) Fatima Bagam TEST\nPhone number:\nCreated: 17 October 2017, 9:27am\nData source: DRS"

--- a/spec/support/helpers/hackney_repairs_request_stubs.rb
+++ b/spec/support/helpers/hackney_repairs_request_stubs.rb
@@ -164,12 +164,14 @@ module Helpers
         {
           "text": "Tenant called to confirm appointment",
           "loggedAt": "2018-08-23T10:12:56+01:00",
-          "loggedBy": "MOSHEA"
+          "loggedBy": "MOSHEA",
+          "noteId": 3000
         },
         {
           "text": "Further works required; Tiler required to renew splash back and reseal bath",
           "loggedAt": "2018-09-02T11:32:14+01:00",
-          "loggedBy": "Servitor"
+          "loggedBy": "Servitor",
+          "noteId": 4000
         }
       ]
     end


### PR DESCRIPTION
Boris has noticed some work orders that should be related aren't.
Adding note-id should make things easier becuase we'll be able to
check neo4j more easily.