### PR TITLE
add profiling to neo4j models

### DIFF
--- a/app/importers/graph_model_importer.rb
+++ b/app/importers/graph_model_importer.rb
@@ -8,18 +8,18 @@ class GraphModelImporter
   end
 
   def import_work_order(work_order_ref:, property_ref:, created:, target_numbers:)
-    return if Graph::WorkOrder.find_by(reference: work_order_ref).present?
+    return if Graph::WorkOrder.profile.find_by(reference: work_order_ref).present?
 
-    work_order = Graph::WorkOrder.create!(reference: work_order_ref,
-                                          property_reference: property_ref,
-                                          created: created,
-                                          source: @source)
+    work_order = Graph::WorkOrder.profile.create!(reference: work_order_ref,
+                                                  property_reference: property_ref,
+                                                  created: created,
+                                                  source: @source)
 
     target_numbers.each do |number|
-      linked = Graph::WorkOrder.find_by(reference: number)
+      linked = Graph::WorkOrder.profile.find_by(reference: number)
       if linked
-        Graph::Citation.cite_by_work_order!(from: work_order, to: linked,
-                                            source: @source)
+        Graph::Citation.profile.cite_by_work_order!(from: work_order, to: linked,
+                                                    source: @source)
       end
     end
 
@@ -27,7 +27,7 @@ class GraphModelImporter
   end
 
   def import_note(note_id:, logged_at:, work_order_reference:, target_numbers:)
-    return if Graph::Note.exists?(note_id: note_id)
+    return if Graph::Note.profile.exists?(note_id: note_id)
 
     work_order = create_graph_models(note_id, logged_at, work_order_reference)
     target_numbers.each do |target_number|
@@ -38,10 +38,10 @@ class GraphModelImporter
   private
 
   def create_graph_models(note_id, logged_at, work_order_reference)
-    Graph::Note.create!(note_id: note_id,
-                        logged_at: logged_at,
-                        source: @source,
-                        work_order_reference: work_order_reference)
+    Graph::Note.profile.create!(note_id: note_id,
+                                logged_at: logged_at,
+                                source: @source,
+                                work_order_reference: work_order_reference)
 
     find_or_create_graph_work_order(work_order_reference)
   end
@@ -50,24 +50,24 @@ class GraphModelImporter
     # We assume that the work order import will have handled all work orders
     # up to a point and do not need to ask the API if a work order exists or not
     target = if target_number <= last_imported_work_order
-               Graph::WorkOrder.find(target_number)
+               Graph::WorkOrder.profile.find(target_number)
              else
                find_or_create_graph_work_order(target_number)
              end
 
-    Graph::Citation.cite_by_note!(from: graph_work_order, to: target,
-                                  note_id: note_id, source: @source)
+    Graph::Citation.profile.cite_by_note!(from: graph_work_order, to: target,
+                                          note_id: note_id, source: @source)
 
   rescue HackneyAPI::RepairsClient::RecordNotFoundError, Neo4j::ActiveNode::Labels::RecordNotFound
     nil # this is fine, target_numbers are not guaranteed to be work orders
   end
 
   def last_imported_work_order
-    @_last ||= Graph::WorkOrder.where(source: WORK_ORDERS_IMPORT).last&.reference || '00000000'
+    @_last ||= Graph::WorkOrder.profile.where(source: WORK_ORDERS_IMPORT).last&.reference || '00000000'
   end
 
   def find_or_create_graph_work_order(work_order_reference)
-    Graph::WorkOrder.find_by(reference: work_order_reference) ||
+    Graph::WorkOrder.profile.find_by(reference: work_order_reference) ||
       create_work_order(work_order_reference)
   end
 

--- a/app/jobs/notes_feed_job.rb
+++ b/app/jobs/notes_feed_job.rb
@@ -6,7 +6,7 @@ class NotesFeedJob < ApplicationJob
   # If NotesFeedJob is performed twice before RelatedWorkOrderJob, then the
   # RelatedWorkOrderJob jobs will be duplicated.
   def perform(enqueues, max_enqueues, enqueue_limit)
-    notes = Hackney::Note.feed(Graph::Note.last_note_id, limit: enqueue_limit)
+    notes = Hackney::Note.feed(Graph::Note.profile.last_note_id, limit: enqueue_limit)
 
     notes.each do |hackney_note|
       RelatedWorkOrderJob.perform_later(hackney_note.note_id,

--- a/app/models/concerns/profiling.rb
+++ b/app/models/concerns/profiling.rb
@@ -1,0 +1,22 @@
+module Profiling
+  extend ActiveSupport::Concern
+
+  class Profiler
+    def initialize(target_class)
+      @target_class = target_class
+    end
+
+    def method_missing(m, *args, &block)
+      caller = caller_locations.first.label
+      Appsignal.instrument("#{caller}->#{@target_class.name}##{m}") do
+        @target_class.send(m, *args, &block)
+      end
+    end
+  end
+
+  class_methods do
+    def profile
+      Profiler.new(self)
+    end
+  end
+end

--- a/app/models/graph/citation.rb
+++ b/app/models/graph/citation.rb
@@ -1,5 +1,6 @@
 class Graph::Citation
   include Neo4j::ActiveRel
+  include Profiling
 
   from_class 'Graph::WorkOrder'
   to_class 'Graph::WorkOrder'

--- a/app/models/graph/last_from_feed.rb
+++ b/app/models/graph/last_from_feed.rb
@@ -5,6 +5,7 @@
 class Graph::LastFromFeed
   include Neo4j::ActiveNode
   include Neo4j::Timestamps::Updated
+  include Profiling
 
   id_property :feed_type
 

--- a/app/models/graph/note.rb
+++ b/app/models/graph/note.rb
@@ -1,5 +1,6 @@
 class Graph::Note
   include Neo4j::ActiveNode
+  include Profiling
 
   id_property :note_id
 

--- a/app/models/graph/work_order.rb
+++ b/app/models/graph/work_order.rb
@@ -1,5 +1,6 @@
 class Graph::WorkOrder
   include Neo4j::ActiveNode
+  include Profiling
   MAX_RELATIONS = 20
 
   id_property :reference


### PR DESCRIPTION
Add a profile method to graph models that sends finer grained info to appsignal. This means we can see which graph operations are slow.

There doesn't seem to be lifecycle hooks that let us easily put extra profiling on neo4j models, so `Graph::Model.profile.do_eet` seemed to be the next best option.