### PR TITLE
Use Graph::LastFromFeed to track which notes have been imported

### DIFF
--- a/app/jobs/notes_feed_job.rb
+++ b/app/jobs/notes_feed_job.rb
@@ -1,18 +1,15 @@
 class NotesFeedJob < ApplicationJob
   queue_as :feed
 
-  # FIXME: NotesFeedJob and RelatedWorkOrderJob must be performed in order.
-  #
-  # If NotesFeedJob is performed twice before RelatedWorkOrderJob, then the
-  # RelatedWorkOrderJob jobs will be duplicated.
   def perform(enqueues, max_enqueues, enqueue_limit)
-    notes = Hackney::Note.feed(Graph::Note.profile.last_note_id, limit: enqueue_limit)
+    notes = Hackney::Note.feed(last_note_id, limit: enqueue_limit)
 
     notes.each do |hackney_note|
       RelatedWorkOrderJob.perform_later(hackney_note.note_id,
                                         hackney_note.logged_at.iso8601,
                                         hackney_note.work_order_reference,
                                         extract_references(hackney_note))
+      Graph::LastFromFeed.update_last_note!(hackney_note.note_id)
     end
 
     if enqueues < max_enqueues && notes.size >= enqueue_limit
@@ -24,6 +21,10 @@ class NotesFeedJob < ApplicationJob
   end
 
   private
+
+  def last_note_id
+    Graph::LastFromFeed.last_note.last_id.to_i
+  end
 
   # Scan the note for possible work order numbers in this job because we don't
   # want to store the text in redis - it may have private information

--- a/app/models/graph/last_from_feed.rb
+++ b/app/models/graph/last_from_feed.rb
@@ -26,4 +26,15 @@ class Graph::LastFromFeed
     ordered_sources = [GraphModelImporter::WORK_ORDERS_IMPORT, WorkOrderFeedJob.source_name]
     Graph::WorkOrder.where(source: ordered_sources, reference: /^\d{8}$/).last&.reference
   end
+
+  def self.last_note
+    last = Graph::LastFromFeed.find_by(feed_type: Graph::Note.name)
+    last ||= Graph::LastFromFeed.create!(feed_type: Graph::Note.name,
+                                         last_id: Graph::Note.last_note_id)
+    last
+  end
+
+  def self.update_last_note!(note_id)
+    last_note.update!(last_id: note_id)
+  end
 end


### PR DESCRIPTION
The performance of Graph::Note.last is quite poor, so just save
the last note imported in neo4j.