### PR TITLE
Allow setting of delayed job wait and sleep via env

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,1 +1,2 @@
 Delayed::Worker.raise_signal_exceptions = :term
+Delayed::Worker.max_attempts = ENV.fetch('DELAYED_JOB_MAX_ATTEMPTS', Delayed::Worker::DEFAULT_MAX_ATTEMPTS).to_i


### PR DESCRIPTION
Need this because the data on the development enviroment/api isn't the best and
we get work order references that don't exist from the notes feed. We're going
to just let any jobs that hit encounter problems fail early on dev so we don't
have any failed jobs just hanging around.