### PR TITLE
Monkeypatch neo4j to fix wait_for_connection.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 worker: LOG_LEVEL=info QUEUE=default rake jobs:work
 feed_worker: QUEUE=feed rake jobs:work
-release: bundle exec rake deploy:wait_and_migrate
+release: bundle exec rake db:migrate

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ module RepairsManagement
     # the framework and any gems in your application.
 
     config.active_job.queue_adapter = :delayed_job
+
+    # Wait for neo4j database to boot up
+    config.neo4j.wait_for_connection = true
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,9 +59,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Wait for neo4j database to boot up
-  config.neo4j.wait_for_connection = true
-
   # Silence sidekiq/web complaints about "Cannot render console from 172.26.0.1"
   config.web_console.whitelisted_ips = '172.26.0.1'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # Wait for neo4j database to boot up
-  config.neo4j.wait_for_connection = true
 end

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -1,0 +1,29 @@
+module Neo4j
+  class SessionManager
+    class << self
+      def open_neo4j_session(type, url_or_path, wait_for_connection = false, options = {})
+        enable_unlimited_strength_crypto! if java_platform? && session_type_is_embedded?(type)
+
+        adaptor = cypher_session_adaptor(type, url_or_path, options.merge(wrap_level: :proc))
+        session = Neo4j::Core::CypherSession.new(adaptor)
+        wait_and_retry(session) if wait_for_connection
+        session
+      end
+
+      protected
+
+      def wait_and_retry(session)
+        Timeout.timeout(60) do
+          begin
+            session.constraints
+          rescue Neo4j::Core::CypherSession::ConnectionFailedError
+            sleep(1)
+            retry
+          end
+        end
+      rescue Timeout::Error
+        raise Timeout::Error, 'Timeout while waiting for connection to neo4j database'
+      end
+    end
+  end
+end

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -15,7 +15,6 @@ module Neo4j
       def wait_and_retry(session)
         Timeout.timeout(60) do
           begin
-            print ?.
             session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError
             sleep(1)

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -15,6 +15,7 @@ module Neo4j
       def wait_and_retry(session)
         Timeout.timeout(60) do
           begin
+            print ?.
             session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError
             sleep(1)

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -13,10 +13,9 @@ module Neo4j
       protected
 
       def wait_and_retry(session)
-        logger = Neo4j::Config[:logger]
         Timeout.timeout(60) do
           begin
-            logger.fatal ?.
+            print ?.
             session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError
             sleep(1)

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -13,7 +13,7 @@ module Neo4j
       protected
 
       def wait_and_retry(session)
-        Timeout.timeout(60) do
+        Timeout.timeout(5*60) do
           begin
             session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError

--- a/config/initializers/fix_neo4j_wait_for_connection.rb
+++ b/config/initializers/fix_neo4j_wait_for_connection.rb
@@ -13,9 +13,10 @@ module Neo4j
       protected
 
       def wait_and_retry(session)
+        logger = Neo4j::Config[:logger]
         Timeout.timeout(60) do
           begin
-            print ?.
+            logger.fatal ?.
             session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError
             sleep(1)


### PR DESCRIPTION
This fix the crash when neo4j takes too long to boot on Heroku review
apps.

See https://github.com/neo4jrb/neo4j/pull/1540