### PR TITLE
Raise a repair errors

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -141,7 +141,7 @@ module HackneyAPI
       )
     end
 
-    def post_repair_request(name:, phone:, sor_code:, priority:, property_ref:, description:)
+    def post_repair_request(name:, phone:, sor_codes:, priority:, property_ref:, description:)
       request(
         http_method: :post,
         endpoint: "#{API_VERSION}/repairs",
@@ -151,9 +151,7 @@ module HackneyAPI
             "name": name,
             "telephoneNumber": phone,
           },
-          "workOrders": [
-            "sorCode": sor_code,
-          ],
+          "workOrders": sor_codes.map {|x| { "sorCode": x } },
           "priority": priority,
           "propertyReference": property_ref,
           "problemDescription": description

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -107,6 +107,18 @@ $govuk-breakpoints: (
   color: govuk-colour("grey-4");
   margin-bottom: 10px;
   padding: 10px 20px;
+
+  /*
+   * FIXME: generic rules should be less specific.
+   * see .hackney-main-section-info p, ul
+   */
+  ul {
+    color: inherit;
+  }
+}
+
+.hackney-flash-message-error {
+  background-color: $govuk-error-colour;
 }
 
 .hackney-note-info {

--- a/app/controllers/repair_requests_controller.rb
+++ b/app/controllers/repair_requests_controller.rb
@@ -15,6 +15,7 @@ class RepairRequestsController < ApplicationController
       if @repair_request.save
         format.html { redirect_to work_order_path(@repair_request.work_orders.first.reference), notice: 'Repair raised!' }
       else
+        flash[:error] = @repair_request.errors["base"]
         format.html { render :new }
       end
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,15 +78,11 @@
     <div class='hackney-flash-message hackney-flash-message-<%= name %>'>
       <div class="govuk-width-container">
         <% messages = [messages].flatten %>
-        <% if 1 == messages.count %>
-          <p><%= messages.first %></p>
-        <% elsif 1 < messages.count %>
-          <ul>
-            <% messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        <% end %>
+        <ul>
+          <% messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,10 +74,19 @@
     </div>
   </header>
 
-  <% flash.each do |name, message| %>
-    <div class='hackney-flash-message'>
+  <% flash.each do |name, messages| %>
+    <div class='hackney-flash-message hackney-flash-message-<%= name %>'>
       <div class="govuk-width-container">
-        <p><%= message %></p>
+        <% messages = [messages].flatten %>
+        <% if 1 == messages.count %>
+          <p><%= messages.first %></p>
+        <% elsif 1 < messages.count %>
+          <ul>
+            <% messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -167,7 +167,7 @@ describe HackneyAPI::RepairsClient do
         api_client.post_repair_request(
           name: "blablabla",
           phone: "01234567890",
-          sor_code: "08500820",
+          sor_codes: ["08500820"],
           priority: "G",
           property_ref: "00000018",
           description: "it's broken fix it"

--- a/spec/models/hackney/repair_request_spec.rb
+++ b/spec/models/hackney/repair_request_spec.rb
@@ -125,7 +125,8 @@ describe Hackney::RepairRequest, '#save' do
           "telephoneNumber": "N/A",
         },
         "workOrders": [
-          "sorCode": "",
+          { "sorCode": "" },
+          { "sorCode": "" }
         ],
         "priority": "G",
         "propertyReference": "00000018",
@@ -135,20 +136,34 @@ describe Hackney::RepairRequest, '#save' do
       status: 400,
       body: [
         {
-          "developerMessage" => "Please provide a valid Problem",
+          "code" => 400,
+          "source" => "/problemDescription",
+          "developerMessage" => "Problem description cannot be null or empty",
           "userMessage" => "Please provide a valid Problem"
         },
         {
-          "developerMessage" => "If Repair request has workOrders you must provide a valid sorCode",
+          "code" => 400,
+          "source" => "/workOrders/0/sorCode",
+          "developerMessage" => "sorCode is invalid",
           "userMessage" => "If Repair request has workOrders you must provide a valid sorCode"
         },
         {
-          "developerMessage" => "Contact Name cannot be empty",
-          "userMessage" => "Contact Name cannot be empty"
+          "code" => 400,
+          "source" => "/workOrders/1/sorCode",
+          "developerMessage" => "sorCode is invalid",
+          "userMessage" => "If Repair request has workOrders you must provide a valid sorCode"
         },
         {
-          "developerMessage" => "Telephone number must contain minimum of 10 and maximum of 11 digits.",
-          "userMessage" => "Telephone number must contain minimum of 10 and maximum of 11 digits."
+          "code" => 400,
+          "source" => "/contact/name",
+          "developerMessage" => "Contact Name cannot be empty",
+          "userMessage" => "Please provide a name for the contact"
+        },
+        {
+          "code" => 400,
+          "source" => "/contact/telephoneNumber",
+          "developerMessage" => "Contact Telephone number is invalid",
+          "userMessage" => "Telephone number must contain minimum of 10 and maximum of 11 digits"
         }
       ].to_json
     )
@@ -159,6 +174,7 @@ describe Hackney::RepairRequest, '#save' do
         telephone_number: ""
       },
       work_orders_attributes: [
+        { sor_code: "" },
         { sor_code: "" }
       ],
       priority: "G",
@@ -170,15 +186,19 @@ describe Hackney::RepairRequest, '#save' do
 
     expect(repair_request.reference).not_to be_present
 
-    expect(repair_request.errors.include?("contact.name")).to be_truthy
-    expect(repair_request.contact.errors.include?("name")).to be_truthy
 
-    expect(repair_request.errors.include?("contact.telephone_number")).to be_truthy
-    expect(repair_request.contact.errors.include?("telephone_number")).to be_truthy
+    expect(repair_request.errors.added?("contact.name", "Please provide a name for the contact")).to be_truthy
+    expect(repair_request.contact.errors.added?("name", "Please provide a name for the contact")).to be_truthy
 
-    expect(repair_request.errors.include?("work_orders[0].sor_code")).to be_truthy
-    expect(repair_request.work_orders[0].errors.include?("sor_code")).to be_truthy
+    expect(repair_request.errors.added?("contact.telephone_number", "Telephone number must contain minimum of 10 and maximum of 11 digits")).to be_truthy
+    expect(repair_request.contact.errors.added?("telephone_number", "Telephone number must contain minimum of 10 and maximum of 11 digits")).to be_truthy
 
-    expect(repair_request.errors.include?("description")).to be_truthy
+    expect(repair_request.errors.added?("work_orders[0].sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
+    expect(repair_request.work_orders[0].errors.added?("sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
+
+    expect(repair_request.errors.added?("work_orders[1].sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
+    expect(repair_request.work_orders[1].errors.added?("sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
+
+    expect(repair_request.errors.added?("description", "Please provide a valid Problem")).to be_truthy
   end
 end


### PR DESCRIPTION
Further improve error reporting on repair_request#new.

See Trello:
https://trello.com/c/xypsQhl7/38-as-a-rcc-agent-when-viewing-a-property-i-need-to-be-able-to-raise-a-new-repair-on-that-property-so-that-i-can-start-a-repair-job