### PR TITLE
Tenure list and colour

### DIFF
--- a/app/assets/stylesheets/hackney_property.scss
+++ b/app/assets/stylesheets/hackney_property.scss
@@ -5,7 +5,7 @@
 }
 
 .hackney-property-tenure-turquoise {
-  background: govuk-colour("turquoise");
+  background: hackney-colour("housing-2");
 }
 
 .hackney-property-tenure-orange {

--- a/app/models/hackney/property.rb
+++ b/app/models/hackney/property.rb
@@ -3,7 +3,7 @@ class Hackney::Property
 
   ESTATE_LEVEL = 2
 
-  RAISABLE_TENURES = %w(INT MPA NON SEC LEA)
+  RAISABLE_TENURES = %w(ASY COM DEC FRS INT LEA MPA NON PVG SEC TAF TGA TRA)
 
   attr_accessor :reference, :level_code, :description, :major_reference, :address, :postcode, :tenure, :tenure_code
 

--- a/app/models/hackney/property.rb
+++ b/app/models/hackney/property.rb
@@ -85,7 +85,7 @@ class Hackney::Property
     level_code == ESTATE_LEVEL
   end
 
-  def can_raise_repair?
+  def can_raise_a_repair?
     RAISABLE_TENURES.include? tenure_code
   end
 end

--- a/app/views/properties/_property_details_top_section.html.erb
+++ b/app/views/properties/_property_details_top_section.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_header do %>
   <h1 class="govuk-heading-l">
     <%= property.address %>
-    <% if property.can_raise_repair? %>
+    <% if property.can_raise_a_repair? %>
       <% if params[:show_raise_a_repair] %>
         <span class="govuk-caption-l">
           <strong>
@@ -24,7 +24,7 @@
         </p>
         <%
           clazz = "govuk-body-s hackney-property-tenure"
-          if property.can_raise_repair?
+          if property.can_raise_a_repair?
             clazz += " hackney-property-tenure-turquoise"
           else
             clazz += " hackney-property-tenure-orange"

--- a/spec/models/hackney/property_spec.rb
+++ b/spec/models/hackney/property_spec.rb
@@ -313,5 +313,41 @@ describe Hackney::Property do
       expect(subject).to eq(result)
     end
   end
+
+  describe '#can_raise_a_repair?' do
+    it 'is only true for some tenure codes' do
+      expect(Hackney::Property.new(tenure_code: 'ASY').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'COM').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'DEC').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'FRE').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'FRS').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'HPH').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'INT').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'LEA').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'LHS').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'LTA').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'MPA').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'NON').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'PVG').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'RSL').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'RTM').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SEC').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'SHO').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SLL').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SMW').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SPS').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SPT').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'SSE').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'TAF').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'TBB').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'TGA').can_raise_a_repair?).to be_truthy
+      expect(Hackney::Property.new(tenure_code: 'THA').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'THL').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'THO').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'TLA').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'TPL').can_raise_a_repair?).to be_falsey
+      expect(Hackney::Property.new(tenure_code: 'TRA').can_raise_a_repair?).to be_truthy
+    end
+  end
 end
 


### PR DESCRIPTION
Update list of properties' tenure types for which repairs can be raised.

Trello:
https://trello.com/c/Wv3V7H9p/46-prevent-raise-a-repair-for-certain-types-of-tenure-s