### PR TITLE
Change from chromedriver-helper to webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ group :test do
   gem 'capybara', '>= 2.15', '< 4.0'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers', '~> 3.0'
   gem 'webmock'
   gem "fakeredis", :require => "fakeredis/rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     appsignal (2.7.2)
       rack
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.107.0)
@@ -92,9 +90,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -148,7 +143,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -334,6 +328,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -355,7 +353,6 @@ DEPENDENCIES
   brakeman
   byebug
   capybara (>= 2.15, < 4.0)
-  chromedriver-helper
   coffee-rails (~> 4.2)
   delayed_job_active_record
   delayed_job_web
@@ -386,6 +383,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 3.0)
   webmock
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'webdrivers'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,7 +1,16 @@
 require 'webmock/rspec'
+
+allowed_sites = [
+  "https://chromedriver.storage.googleapis.com",
+  "https://github.com/mozilla/geckodriver/releases",
+  "https://selenium-release.storage.googleapis.com",
+  "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  %{neo4j_db_test}
+]
+
 WebMock.disable_net_connect!({
   allow_localhost: true,
-  allow: %{neo4j_db_test}
+  allow: allowed_sites
 })
 
 WebMock::Config.instance.query_values_notation = :flat_array


### PR DESCRIPTION
Chromedriver-helper is out of support from April 2019, they suggest using webdrivers instead.