### PR TITLE
Raise a repair with email

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -141,7 +141,7 @@ module HackneyAPI
       )
     end
 
-    def post_repair_request(name:, phone:, sor_codes:, priority:, property_ref:, description:)
+    def post_repair_request(name:, phone:, sor_codes:, priority:, property_ref:, description:, created_by_email:)
       request(
         http_method: :post,
         endpoint: "#{API_VERSION}/repairs",
@@ -154,7 +154,8 @@ module HackneyAPI
           "workOrders": sor_codes.map {|x| { "sorCode": x } },
           "priority": priority,
           "propertyReference": property_ref,
-          "problemDescription": description
+          "problemDescription": description,
+          "lbhEmail": created_by_email
         }.to_json
       )
     end

--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -259,6 +259,8 @@ module HackneyAPI
         Appsignal.instrument("api.#{caller}") do
           connection(cache_request: cache_request, headers: headers).public_send(http_method, endpoint, params)
         end
+      rescue WebMock::NetConnectNotAllowedError, VCR::Errors::UnhandledHTTPRequestError
+        raise
       rescue => e
         Rails.logger.error(e)
         raise ApiError, [endpoint, params, e.message].join(', ')

--- a/app/controllers/repair_requests_controller.rb
+++ b/app/controllers/repair_requests_controller.rb
@@ -29,6 +29,7 @@ class RepairRequestsController < ApplicationController
   def create
     @repair_request = Hackney::RepairRequest.new(repair_request_params)
     @repair_request.property_reference = @property.reference
+    @repair_request.created_by_email = session[:current_user]["email"]
     respond_to do |format|
       if @repair_request.save
         format.html { redirect_to work_order_path(@repair_request.work_orders.first.reference), notice: ['Repair raised!'] }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,14 +13,20 @@ class SessionsController < ApplicationController
   end
 
   def create
-    session[:current_user] = { name: auth_hash.info.name }
+    session[:current_user] = {
+      name: auth_hash.info.name,
+      email: auth_hash.info.email
+    }
     flash[:notice] = ["You have logged in as #{auth_hash.info.name}"]
     redirect_to root_path
   end
 
   def review_app_login
     if review_app_login? && review_app_compare(params[:username], params[:password])
-      session[:current_user] = { name: 'Review User' }
+      session[:current_user] = {
+        name: 'Review User',
+        email: ENV['REVIEW_USER_EMAIL']
+      }
       flash[:notice] = ["You have logged in as Review User"]
       redirect_to root_path
     else

--- a/app/models/hackney/repair_request.rb
+++ b/app/models/hackney/repair_request.rb
@@ -1,7 +1,8 @@
 class Hackney::RepairRequest
   include ActiveModel::Model
 
-  attr_accessor :reference, :description, :contact, :priority, :work_orders, :property_reference
+  attr_accessor :reference, :description, :contact, :priority, :work_orders,
+    :property_reference, :created_by_email
 
   NULL_OBJECT = self.new(description: 'Repair info missing')
 
@@ -46,10 +47,13 @@ class Hackney::RepairRequest
       sor_codes: work_orders&.map(&:sor_code) || [],
       priority: priority,
       property_ref: property_reference,
-      description: description
+      description: description,
+      created_by_email: created_by_email
     )
     self.attributes = self.class.attributes_from_api(response)
     true
+
+    # FIXME: rescue is grabbing VCR errors
   rescue HackneyAPI::RepairsClient::ApiError => e
     self.class.errors_from_api(e.errors).each do |key, list|
       list.each do |msg|

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -159,7 +159,8 @@ describe HackneyAPI::RepairsClient do
           ],
           "priority": "G",
           "propertyReference": "00000018",
-          "problemDescription": "it's broken fix it"
+          "problemDescription": "it's broken fix it",
+          "lbhEmail": "pudding@hackney.gov.uk"
         }.to_json
       ).to_return(status: 200, body: '{"works": true }')
 
@@ -170,7 +171,8 @@ describe HackneyAPI::RepairsClient do
           sor_codes: ["08500820"],
           priority: "G",
           property_ref: "00000018",
-          description: "it's broken fix it"
+          description: "it's broken fix it",
+          created_by_email: "pudding@hackney.gov.uk"
         )
       ).to be == {"works" => true}
     end

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -307,9 +307,8 @@ RSpec.describe 'Repair request' do
 
   context 'Leasehold RTB tenure' do
     scenario 'Cannot raise repair', :js do
-      stub_post_repair_request
-      stub_property_temp_annex
       sign_in
+      stub_property_temp_annex
       visit property_path('207044451')
 
       expect(page).to have_css(".hackney-property-warning-label-orange")

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe 'Repair request' do
         }],
         "priority": "E",
         "propertyReference": "00000666",
-        "problemDescription": "It's broken"
+        "problemDescription": "It's broken",
+        "lbhEmail": Helpers::Authentication::EMAIL
       }.to_json
     ).to_return(
       status: 200,
@@ -58,7 +59,8 @@ RSpec.describe 'Repair request' do
         }],
         "priority": "E",
         "propertyReference": "00000666",
-        "problemDescription": "It's broken"
+        "problemDescription": "It's broken",
+        "lbhEmail": Helpers::Authentication::EMAIL
       }.to_json
     ).to_return(
       status: 500,

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -240,11 +240,9 @@ RSpec.describe 'Repair request' do
       }.to_json
     )
 
-    stub_request(:get, "#{ ENV['HACKNEY_REPAIRS_API_BASE_URL'] }/v1/work_orders?since=23-05-2017&until=24-05-2019").to_return(
-      status: 200,
-      body: [].to_json
-    )
-    end
+    stub_request(:get, "#{ ENV['HACKNEY_REPAIRS_API_BASE_URL'] }/v1/work_orders?since=#{2.years.ago.strftime("%d-%m-%Y")}&until=#{1.day.from_now.strftime("%d-%m-%Y")}")
+      .to_return(status: 200, body: [].to_json)
+  end
 
   context 'Secure tenure' do
     scenario 'Raise a repair successfully', :js do

--- a/spec/models/hackney/repair_request_spec.rb
+++ b/spec/models/hackney/repair_request_spec.rb
@@ -70,7 +70,8 @@ describe Hackney::RepairRequest, '#save' do
         ],
         "priority": "G",
         "propertyReference": "00000018",
-        "problemDescription": "it's broken fix it"
+        "problemDescription": "it's broken fix it",
+        "lbhEmail": "pudding@hackney.gov.uk"
       }.to_json
     ).to_return(
       status: 200,
@@ -103,7 +104,8 @@ describe Hackney::RepairRequest, '#save' do
       ],
       priority: "G",
       property_reference: "00000018",
-      description: "it's broken fix it"
+      description: "it's broken fix it",
+      created_by_email: "pudding@hackney.gov.uk"
     )
 
     repair_request.save
@@ -130,7 +132,8 @@ describe Hackney::RepairRequest, '#save' do
         ],
         "priority": "G",
         "propertyReference": "00000018",
-        "problemDescription": ""
+        "problemDescription": "",
+        "lbhEmail": "pudding@hackney.gov.uk"
       }.to_json
     ).to_return(
       status: 400,
@@ -179,7 +182,8 @@ describe Hackney::RepairRequest, '#save' do
       ],
       priority: "G",
       property_reference: "00000018",
-      description: ""
+      description: "",
+      created_by_email: "pudding@hackney.gov.uk"
     )
 
     expect(repair_request.save).to be_falsey

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -1,12 +1,16 @@
 module Helpers
   module Authentication
+    NAME = 'Mike Ross'
+    EMAIL = 'pudding@hackney.gov.uk'
+
     RSpec.configure do |config|
       config.before :each, type: :feature do
         OmniAuth.config.test_mode = true
         OmniAuth.config.mock_auth[:azureactivedirectory] = OmniAuth::AuthHash.new({
           provider: 'azureactivedirectory',
           info: OmniAuth::AuthHash::InfoHash.new({
-            name: 'Mike Ross'
+            name: NAME,
+            email: EMAIL
           })
         })
       end


### PR DESCRIPTION
Pass current user's email when raising a repair so that the API will know who is accountable.

Trello card:

https://trello.com/c/U1ii1tMi/101-as-an-rcc-manager-i-want-to-see-who-raised-a-repair-in-repairs-hub-so-that-i-know-who-is-accountable-and-run-reports