### PR TITLE
Fix default repair history filter selection.

### DIFF
--- a/app/controllers/api/properties_controller.rb
+++ b/app/controllers/api/properties_controller.rb
@@ -5,6 +5,8 @@ module Api
 
       @property = Hackney::Property.find(reference)
 
+      # FIXME: this variable name is very misleading, Property#hierarchy exists
+      # and is in fact contained in this set along with Property#facilities.
       @property_hierarchy = @property.dwelling_work_orders_hierarchy(years_ago)
 
       @trades = @property_hierarchy.values.flatten.map(&:trade).uniq.sort

--- a/app/views/api/properties/_repair_history_filters.html.erb
+++ b/app/views/api/properties/_repair_history_filters.html.erb
@@ -16,7 +16,7 @@
       <div class="hierarchy-hackney-checkbox">
         <% hierarchy.keys.each_with_index do |description, index| %>
           <div class="work-order-filter-options govuk-body-s">
-            <input onclick="applyBuildingFilter('<%= description.parameterize %>-tab', '<%= description.parameterize %>-content')" class="hierarchy-filter-checkbox tabelement" id="hierarchy-<%=index%>" type="radio" value="hierarchy-<%=index%>" name="hierarchy" <%= 'checked' if index == 0%>>
+            <input onclick="applyBuildingFilter('<%= description.parameterize %>-tab', '<%= description.parameterize %>-content')" class="hierarchy-filter-checkbox tabelement" id="hierarchy-<%=index%>" type="radio" value="hierarchy-<%=index%>" name="hierarchy" <%= 'checked' if description == @property.description %>>
             <label class="hackney-checkboxes__label" for="hierarchy-<%=index%>">
               <%= description %>
             </label>


### PR DESCRIPTION
Trello:
https://trello.com/c/9eUdavvv/149-as-an-rcc-agent-when-looking-at-the-repairs-history-on-a-block-i-need-the-block-to-be-selected-by-default-on-the-filters-list