### PR TITLE
Add addresses to repair history filters.

### DIFF
--- a/app/assets/stylesheets/hackney_trade_and_hierarchy_filtering.scss
+++ b/app/assets/stylesheets/hackney_trade_and_hierarchy_filtering.scss
@@ -10,6 +10,23 @@
     border-bottom: none;
   }
 }
+
+/* truncate addresses with "..." */
+.work-order-filter {
+  min-inline-size: auto;
+
+  .work-order-filter-options {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .work-orders-filter-option-address {
+    color: $govuk-secondary-text-colour;
+    padding-left: 5px;
+  }
+}
+
 .filter_heading {
   border-bottom: none;
   display: flex;

--- a/app/views/api/properties/_repair_history_filters.html.erb
+++ b/app/views/api/properties/_repair_history_filters.html.erb
@@ -19,6 +19,11 @@
             <input onclick="applyBuildingFilter('<%= description.parameterize %>-tab', '<%= description.parameterize %>-content')" class="hierarchy-filter-checkbox tabelement" id="hierarchy-<%=index%>" type="radio" value="hierarchy-<%=index%>" name="hierarchy" <%= 'checked' if description == @property.description %>>
             <label class="hackney-checkboxes__label" for="hierarchy-<%=index%>">
               <%= description %>
+              <% if %w(Estate Block Sub-Block Dwelling).include? description %>
+                <small class="work-orders-filter-option-address">
+                  <%= @property.hierarchy.find {|p| p.description == description}.address %>
+                </small>
+              <% end %>
             </label>
           </div>
         <% end %>


### PR DESCRIPTION
Trello:
https://trello.com/c/pFKBsFzZ/144-as-an-rcc-agent-when-filtering-the-repairs-history-i-need-to-know-which-block-or-sub-block-which-numbers-im-looking-at