### PR TITLE
Fix default repair history filter tab contents.

### DIFF
--- a/app/views/api/properties/_repair_history_filters.html.erb
+++ b/app/views/api/properties/_repair_history_filters.html.erb
@@ -14,9 +14,11 @@
       </div>
 
       <div class="hierarchy-hackney-checkbox">
+        <% #FIXME: this is ugly and duplicated in app/views/api/properties/repairs_history.html.erb %>
+        <% default_filter_index = hierarchy.keys.index(@property.description) || 0 %>
         <% hierarchy.keys.each_with_index do |description, index| %>
           <div class="work-order-filter-options govuk-body-s">
-            <input onclick="applyBuildingFilter('<%= description.parameterize %>-tab', '<%= description.parameterize %>-content')" class="hierarchy-filter-checkbox tabelement" id="hierarchy-<%=index%>" type="radio" value="hierarchy-<%=index%>" name="hierarchy" <%= 'checked' if description == @property.description %>>
+            <input onclick="applyBuildingFilter('<%= description.parameterize %>-tab', '<%= description.parameterize %>-content')" class="hierarchy-filter-checkbox tabelement" id="hierarchy-<%=index%>" type="radio" value="hierarchy-<%=index%>" name="hierarchy" <%= 'checked' if index == default_filter_index %>>
             <label class="hackney-checkboxes__label" for="hierarchy-<%=index%>">
               <%= description %>
               <% if %w(Estate Block Sub-Block Dwelling).include? description %>

--- a/app/views/api/properties/repairs_history.html.erb
+++ b/app/views/api/properties/repairs_history.html.erb
@@ -5,8 +5,10 @@
 <div class="govuk-grid-row">
   <%= render 'repair_history_filters', hierarchy: @property_hierarchy, work_orders_trades: @trades %>
 
+  <% #FIXME: this is ugly and duplicated in app/views/api/properties/_repair_history_filters.html.erb %>
+  <% default_filter_index = @property_hierarchy.keys.index(@property.description) || 0 %>
   <% @property_hierarchy.each_with_index do |(description, work_orders), index| %>
-    <div class="tabcontent <%= 'hidden' unless index == 0 %>" id="<%= description.parameterize %>-content">
+    <div class="tabcontent <%= 'hidden' unless index == default_filter_index %>" id="<%= description.parameterize %>-content">
       <div class="govuk-grid-column-three-quarters">
 
         <table class="govuk-table hackney-history hackney-work-order-table">


### PR DESCRIPTION
Trello:
https://trello.com/c/9eUdavvv/149-as-an-rcc-agent-when-looking-at-the-repairs-history-on-a-block-i-need-the-block-to-be-selected-by-default-on-the-filters-list