### PR TITLE
Add agent name to post_word_order_note

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -87,7 +87,7 @@ module HackneyAPI
       )
     end
 
-    def post_work_order_note(work_order_reference, text)
+    def post_work_order_note(work_order_reference, text, created_by_email)
       value = request(
         http_method: :post,
         endpoint: "#{API_VERSION}/notes",
@@ -95,7 +95,8 @@ module HackneyAPI
         params: {
           objectKey: "uhorder",
           objectReference: work_order_reference,
-          text: text
+          text: text,
+          lbhemail: created_by_email
         }.to_json
       )
 

--- a/app/controllers/api/work_orders_controller.rb
+++ b/app/controllers/api/work_orders_controller.rb
@@ -15,7 +15,8 @@ module Api
       notes_text = params[:note][:text]
 
       if notes_text.present? && notes_text.length <= 2000
-        Hackney::Note.create_work_order_note(reference, params[:note][:text])
+        created_by_email = session[:current_user]["email"]
+        Hackney::Note.create_work_order_note(reference, params[:note][:text], created_by_email)
         @notes_and_appointments = get_notes_and_appointments(@work_order)
 
         render 'notes_and_appointments'

--- a/app/models/hackney/note.rb
+++ b/app/models/hackney/note.rb
@@ -24,7 +24,7 @@ class Hackney::Note
     HackneyAPI::RepairsClient.new.notes_feed(note_id, opts).map { |attrs| Hackney::Note.build(attrs) }
   end
 
-  def self.create_work_order_note(work_order_reference, text)
-    HackneyAPI::RepairsClient.new.post_work_order_note(work_order_reference, text)
+  def self.create_work_order_note(work_order_reference, text, created_by_email)
+    HackneyAPI::RepairsClient.new.post_work_order_note(work_order_reference, text, created_by_email)
   end
 end

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -578,7 +578,7 @@ describe HackneyAPI::RepairsClient do
 
   describe '#post_work_order_note' do
 
-    subject { api_client.post_work_order_note("00000001", "It's all fine") }
+    subject { api_client.post_work_order_note("00000001", "It's all fine", "Celia") }
 
     context 'successful response' do
       it 'posts a note' do
@@ -587,7 +587,8 @@ describe HackneyAPI::RepairsClient do
               body: {
                 objectKey: "uhorder",
                 objectReference: "00000001",
-                text: "It's all fine"}.to_json)
+                text: "It's all fine",
+                lbhemail: "Celia" }.to_json)
         .to_return(status: 204)
 
         expect(subject).to eq(nil)

--- a/spec/models/hackney/note.rb
+++ b/spec/models/hackney/note.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Hackney::Note do
+  def stub_get_notes
+    stub_request(:get, "https://hackneyrepairs/v1/work_orders/01551932/notes")
+      .to_return(status: 200,
+        body: [{
+          "text": "Tenant called to confirm appointment",
+          "loggedAt": "2018-08-23T10:12:56+01:00",
+          "loggedBy": "MOSHEA",
+          "noteId": 3000
+        }].to_json)
+  end
+
+  describe '.for_work_order' do
+    it 'returns a response' do
+      stub_get_notes
+      response = Hackney::Note.for_work_order('01551932')
+
+      expect(response.first.text).to eq('Tenant called to confirm appointment')
+      expect(response.first.logged_by).to eq('MOSHEA')
+      expect(response.first.note_id).to eq(3000)
+    end
+  end
+
+  def stub_post_a_note
+    stub_request(:post, "https://hackneyrepairs/v1/notes").with(
+      headers: {
+        "Content-Type" => "application/json-patch+json"
+      },
+      body: {"objectKey": "uhorder",
+        "objectReference": "01234567",
+        "text": "This is a note",
+        "lbhemail": "Celia"
+      }.to_json
+    ).to_return(
+      status: 200,
+      body: {
+        "text": "This is a note",
+        "loggedAt": "2019-06-10 12:39:51 +0100",
+        "loggedBy": "Celia",
+        "noteId": 3000,
+        "workOrderReference": "01234567"
+        }.to_json
+      )
+  end
+
+  describe '.create_work_order_note' do
+    it 'creates a note' do
+      stub_post_a_note
+
+      note_response = Hackney::Note.create_work_order_note(
+        "01234567", "This is a note", "Celia"
+      )
+
+      note = Hackney::Note.build(note_response)
+
+      expect(note.text).to eq("This is a note")
+      expect(note.logged_by).to eq("Celia")
+      expect(note.note_id).to eq(3000)
+    end
+  end
+end


### PR DESCRIPTION
Relating to this trello card: https://trello.com/c/lHrgTehb/39-as-an-rcc-agent-when-i-view-case-notes-i-need-to-see-the-persons-name-who-added-the-notes-and-not-the-it-program-they-were-using