### PR TITLE
Check for single/plural property type

### DIFF
--- a/app/controllers/api/properties_controller.rb
+++ b/app/controllers/api/properties_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class PropertiesController < Api::ApiController
-
     def repairs_history
       years_ago = params[:years_ago]&.to_i || 2
 

--- a/app/controllers/api/properties_controller.rb
+++ b/app/controllers/api/properties_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class PropertiesController < Api::ApiController
+
     def repairs_history
       years_ago = params[:years_ago]&.to_i || 2
 

--- a/app/views/api/properties/_load_repairs_history_button.html.erb
+++ b/app/views/api/properties/_load_repairs_history_button.html.erb
@@ -3,7 +3,13 @@
     <% if work_orders.any? %>
       Repairs history is showing jobs raised in the <strong>last 2 years</strong>.
     <% else %>
-      There are no work orders for this <%= property_description.downcase %> within the <strong>last 2 years</strong>.
+      There are no work orders for
+      <% if property_description.downcase == "facilities" %>
+        these facilities
+      <% else %>
+        this <%= property_description.downcase %>
+      <% end %>
+      within the <strong>last 2 years</strong>.
     <% end %>
   </p>
 


### PR DESCRIPTION
When there are no work orders for the facilities, change the explanation to "There are no work orders for these facilities" 