### PR TITLE
Change error message when note is not submitted

### DIFF
--- a/app/assets/javascripts/ajax.js
+++ b/app/assets/javascripts/ajax.js
@@ -64,7 +64,7 @@ function postAjaxForm(event, destinationId) {
 
   sendAjaxRequest('POST', form.action, FD, csrfToken,
     function (request) { destination.innerHTML = request.response; },
-    function () { destination.innerHTML = "There was a problem submitting your form"; }
+    function () { destination.innerHTML = "There was a problem submitting your form. Please contact an administrator to check that your account is set up correctly."; }
   );
 }
 


### PR DESCRIPTION
further linked to: https://trello.com/c/lHrgTehb/39-as-an-rcc-agent-when-i-view-case-notes-i-need-to-see-the-persons-name-who-added-the-notes-and-not-the-it-program-they-were-using