### PR TITLE
Fix repair_request#new description lost on error.

### DIFF
--- a/app/controllers/repair_requests_controller.rb
+++ b/app/controllers/repair_requests_controller.rb
@@ -19,7 +19,8 @@ class RepairRequestsController < ApplicationController
       work_orders_attributes: [{
         sor_code: @keyfax_result&.sor_code,
         }],
-      priority: @keyfax_result&.priority
+      priority: @keyfax_result&.priority,
+      description: @keyfax_result&.fault_text
     )
 
     @cautionary_contacts = Hackney::CautionaryContact.find_by_property_reference(@property.reference)

--- a/app/views/repair_requests/new.html.erb
+++ b/app/views/repair_requests/new.html.erb
@@ -64,8 +64,7 @@
         </span>
 
         <%= form.error_messages :description %>
-        <% # FIXME: why value: @keyfax_result&.fault_text ??? %>
-        <%= form.text_area :description, value: @keyfax_result&.fault_text, class: 'govuk-textarea', rows: 5 %>
+        <%= form.text_area :description, class: 'govuk-textarea', rows: 5 %>
       <% end %>
 
       <%= form.fields_for :contact do |fields| %>


### PR DESCRIPTION
Trello: https://trello.com/c/q3GV2djj/166-as-an-rcc-agent-after-ive-filled-in-the-details-on-the-new-repair-form-i-want-this-to-not-disappear-when-theres-an-error