### PR TITLE
Clear repairs history cache after raising repair.

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -142,8 +142,20 @@ module HackneyAPI
       )
     end
 
+    # Try to clear cache for requests that have this work order.
+    # NOTE: there might be requests not covered here.
+    def self.clear_work_orders_cache_for_property(property_reference)
+      API_REQUEST_CACHE.delete_matched "*work_order*#{property_reference}*"
+    end
+
+    # Try to clear cache for requests that have this repair request.
+    # NOTE: there might be requests not covered here.
+    def self.clear_repairs_cache_for_property(property_reference)
+      API_REQUEST_CACHE.delete_matched "*repairs*#{property_reference}*"
+    end
+
     def post_repair_request(name:, phone:, sor_codes:, priority:, property_ref:, description:, created_by_email:)
-      request(
+      response = request(
         http_method: :post,
         endpoint: "#{API_VERSION}/repairs",
         headers: {"Content-Type" => "application/json-patch+json"},
@@ -159,6 +171,11 @@ module HackneyAPI
           "lbhEmail": created_by_email
         }.to_json
       )
+
+      self.class.clear_work_orders_cache_for_property(property_ref)
+      self.class.clear_repairs_cache_for_property(property_ref)
+
+      response
     end
 
     def post_work_order_issue(reference, created_by_email:)

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -142,22 +142,26 @@ describe HackneyAPI::RepairsClient do
   describe ".clear_work_orders_cache_for_property" do
     it "works" do
       API_REQUEST_CACHE.write("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666", "1")
+      API_REQUEST_CACHE.write("hackney-api-cache-/v1/properties/00000666", "2")
       expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666")).to be_truthy
 
       HackneyAPI::RepairsClient.clear_work_orders_cache_for_property("00000666")
 
       expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666")).to be_falsey
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/properties/00000666")).to be_truthy
     end
   end
 
   describe ".clear_repairs_cache_for_property" do
     it "works" do
       API_REQUEST_CACHE.write("hackney-api-cache-/v1/repairs?propertyReference=00000666", "2")
+      API_REQUEST_CACHE.write("hackney-api-cache-/v1/properties/00000666", "2")
       expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/repairs?propertyReference=00000666")).to be_truthy
 
       HackneyAPI::RepairsClient.clear_repairs_cache_for_property("00000666")
 
       expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/repairs?propertyReference=00000666")).to be_falsey
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/properties/00000666")).to be_truthy
     end
   end
 

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -139,6 +139,28 @@ describe HackneyAPI::RepairsClient do
     end
   end
 
+  describe ".clear_work_orders_cache_for_property" do
+    it "works" do
+      API_REQUEST_CACHE.write("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666", "1")
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666")).to be_truthy
+
+      HackneyAPI::RepairsClient.clear_work_orders_cache_for_property("00000666")
+
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/work_orders?propertyReference=00000666&since=06-06-0666&until=06-06-6666")).to be_falsey
+    end
+  end
+
+  describe ".clear_repairs_cache_for_property" do
+    it "works" do
+      API_REQUEST_CACHE.write("hackney-api-cache-/v1/repairs?propertyReference=00000666", "2")
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/repairs?propertyReference=00000666")).to be_truthy
+
+      HackneyAPI::RepairsClient.clear_repairs_cache_for_property("00000666")
+
+      expect(API_REQUEST_CACHE.exist?("hackney-api-cache-/v1/repairs?propertyReference=00000666")).to be_falsey
+    end
+  end
+
   describe '#post_repair_request' do
     pending "invalid SOR code 4896802H"
 
@@ -163,6 +185,9 @@ describe HackneyAPI::RepairsClient do
           "lbhEmail": "pudding@hackney.gov.uk"
         }.to_json
       ).to_return(status: 200, body: '{"works": true }')
+
+      expect(HackneyAPI::RepairsClient).to receive(:clear_work_orders_cache_for_property)
+      expect(HackneyAPI::RepairsClient).to receive(:clear_repairs_cache_for_property)
 
       expect(
         api_client.post_repair_request(


### PR DESCRIPTION
Trello:
https://trello.com/c/g3JLfJ8I/178-bug-sometimes-work-orders-are-cached-and-the-new-ones-dont-show-after-raising-a-repair