### PR TITLE
Show cc and tenure on works order page

### DIFF
--- a/app/controllers/work_orders_controller.rb
+++ b/app/controllers/work_orders_controller.rb
@@ -18,6 +18,7 @@ class WorkOrdersController < ApplicationController
 
   def show
     @work_order = WorkOrderFacade.new(reference)
+    @cautionary_contacts = Hackney::CautionaryContact.find_by_property_reference(@work_order.property.reference)
   end
 
 private

--- a/app/views/properties/_property_details_top_section.html.erb
+++ b/app/views/properties/_property_details_top_section.html.erb
@@ -31,31 +31,8 @@
           </span><br>
           <%= property.postcode %>
         </p>
-        <div class="hackney-warning-labels">
-          <%
-          clazz = "govuk-body-s hackney-property-warning-label"
-          if property.can_raise_a_repair?
-          clazz += " hackney-property-warning-label-turquoise"
-          else
-          clazz += " hackney-property-warning-label-orange"
-          end
-          %>
-          <% if property.tenure.present? %>
-          <p class="<%= clazz %>">
-            <%= property.tenure %>
-          </p>
-          <% end %>
 
-          <% if property.is_tmo? %>
-          <p class="govuk-body-s hackney-property-warning-label hackney-property-warning-label-orange">
-            <%= property.letting_area %>
-          </p>
-          <% end %>
-
-          <% if @cautionary_contacts.present? %>
-            <%= render :partial => 'shared/cautionary_contact_table', locals: { cautionary_contacts: @cautionary_contacts } %>
-          <% end %>
-        </div>
+        <%= render :partial => 'shared/tenure_and_cautionary_contact_info', locals: { property: property } %>
 
       </div>
     </div>

--- a/app/views/shared/_tenure_and_cautionary_contact_info.html.erb
+++ b/app/views/shared/_tenure_and_cautionary_contact_info.html.erb
@@ -1,0 +1,25 @@
+<div class="hackney-warning-labels">
+  <%
+  clazz = "govuk-body-s hackney-property-warning-label"
+  if property.can_raise_a_repair?
+  clazz += " hackney-property-warning-label-turquoise"
+  else
+  clazz += " hackney-property-warning-label-orange"
+  end
+  %>
+  <% if property.tenure.present? %>
+  <p class="<%= clazz %>">
+    <%= property.tenure %>
+  </p>
+  <% end %>
+
+  <% if property.is_tmo? %>
+  <p class="govuk-body-s hackney-property-warning-label hackney-property-warning-label-orange">
+    <%= property.letting_area %>
+  </p>
+  <% end %>
+
+  <% if @cautionary_contacts.present? %>
+    <%= render :partial => 'shared/cautionary_contact_table', locals: { cautionary_contacts: @cautionary_contacts } %>
+  <% end %>
+</div>

--- a/app/views/work_orders/_work_order_reference_top_section.html.erb
+++ b/app/views/work_orders/_work_order_reference_top_section.html.erb
@@ -34,6 +34,9 @@
             <%= work_order.property.postcode %>
           </span><br>
         </p>
+
+        <%= render :partial => 'shared/tenure_and_cautionary_contact_info', locals: { property: work_order.property } %>
+
       </div>
     </div>
 

--- a/spec/features/work_order_spec.rb
+++ b/spec/features/work_order_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe 'Work order' do
     expect(page).to have_content 'TEST problem'
 
     expect(page).to have_content "Homerton High Street 12 Banister House\nE9 6BH"
+    expect(page).to have_content "Lordship South TMO (SN) H2556"
 
     expect(page).to have_content 'Status: In Progress'
     expect(page).to have_content "Mr Suleyman Erbas"

--- a/spec/features/work_order_spec.rb
+++ b/spec/features/work_order_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe 'Work order' do
     expect(page).to have_content 'TEST problem'
 
     expect(page).to have_content "Homerton High Street 12 Banister House\nE9 6BH"
+    expect(page).to have_content "Secure"
     expect(page).to have_content "Lordship South TMO (SN) H2556"
 
     expect(page).to have_content 'Status: In Progress'

--- a/spec/support/helpers/hackney_repairs_request_stubs.rb
+++ b/spec/support/helpers/hackney_repairs_request_stubs.rb
@@ -83,7 +83,8 @@ module Helpers
                                   maintainable: true,
                                   level_code: 7,
                                   description: "Dwelling",
-                                  letting_area: "Lordship South TMO (SN) H2556")
+                                  letting_area: "Lordship South TMO (SN) H2556",
+                                  tenure: "Secure")
       {
         "address" => address,
         "postcode" => postcode,
@@ -91,7 +92,8 @@ module Helpers
         "maintainable" => maintainable,
         "levelCode" => level_code,
         "description" => description,
-        "lettingArea" => letting_area
+        "lettingArea" => letting_area,
+        "tenure" => tenure
       }
     end
 


### PR DESCRIPTION
https://trello.com/c/MTOB02WQ/152-as-an-rcc-agent-when-looking-at-a-work-order-page-i-want-to-see-the-tenure-type-cautionary-contact-tmo-details