### PR TITLE
Add cc info to new repair request description

### DIFF
--- a/app/controllers/repair_requests_controller.rb
+++ b/app/controllers/repair_requests_controller.rb
@@ -20,11 +20,14 @@ class RepairRequestsController < ApplicationController
         sor_code: @keyfax_result&.sor_code,
         }],
       priority: @keyfax_result&.priority,
-      description: @keyfax_result&.fault_text
+      description: @problem_description
     )
 
     @cautionary_contacts = Hackney::CautionaryContact.find_by_property_reference(@property.reference)
     @keyfax_session = Hackney::KeyfaxSession.create(current_page_url: new_property_repair_request_url(@property.reference))
+    @problem_description = @cautionary_contacts.map do |cautionary_contact|
+      cautionary_contact.alert_code
+    end.join("; ")
   end
 
   def create
@@ -38,6 +41,7 @@ class RepairRequestsController < ApplicationController
       else
         @cautionary_contacts = Hackney::CautionaryContact.find_by_property_reference(@property.reference)
         @keyfax_session = Hackney::KeyfaxSession.create(current_page_url: new_property_repair_request_url(@property.reference))
+        @problem_description = @repair_request.description
         flash.now[:error] = @repair_request.errors["base"]
         format.html { render :new }
       end

--- a/app/views/repair_requests/new.html.erb
+++ b/app/views/repair_requests/new.html.erb
@@ -59,7 +59,7 @@
       <%= form.form_group :description do %>
         <%= form.label :description, "Problem description" %>
         <%= form.error_messages :description %>
-        <%= form.text_area :description, value: @problem_description, class: 'govuk-textarea govuk-!-margin-bottom-1', maxlength: 250, rows: 4, onkeyup: 'characterCount()' %>
+        <%= form.text_area :description, class: 'govuk-textarea govuk-!-margin-bottom-1', maxlength: 250, rows: 4, onkeyup: 'characterCount()' %>
         <span class="govuk-hint">
           You have <span id="counter" data-maximum-length="250">250</span> characters remaining.
           Anything over the limit should be added to the work order's notes.

--- a/app/views/repair_requests/new.html.erb
+++ b/app/views/repair_requests/new.html.erb
@@ -59,7 +59,7 @@
       <%= form.form_group :description do %>
         <%= form.label :description, "Problem description" %>
         <%= form.error_messages :description %>
-        <%= form.text_area :description, class: 'govuk-textarea govuk-!-margin-bottom-1', maxlength: 250, rows: 4, onkeyup: 'characterCount()' %>
+        <%= form.text_area :description, value: @problem_description, class: 'govuk-textarea govuk-!-margin-bottom-1', maxlength: 250, rows: 4, onkeyup: 'characterCount()' %>
         <span class="govuk-hint">
           You have <span id="counter" data-maximum-length="250">250</span> characters remaining.
           Anything over the limit should be added to the work order's notes.

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Repair request' do
       body: {
         "repairRequestReference" => "03210303",
         "propertyReference" =>"00000666",
-        "problemDescription" => "CC Electric lighting: Communal; Block Lighting; 3; All lights out", 
+        "problemDescription" => "CC Electric lighting: Communal; Block Lighting; 3; All lights out",
         "priority" => "N",
         "contact" => {
           "name" => "Miss Piggy",
@@ -298,16 +298,15 @@ RSpec.describe 'Repair request' do
       expect(page).to have_css(".hackney-property-warning-label-turquoise")
       click_on 'Raise a repair on this dwelling'
 
-      page.should have_css('.hackney-cautionary-contact-table')
+      expect(page).to have_css('.hackney-cautionary-contact-table')
       expect(page).to have_link("Launch Keyfax", href: "https://www.keyfax.com")
-      expect(find_by_id('hackney_repair_request_description')).to have_content 'CC'
 
       stub_keyfax_get_results_response
 
       visit new_property_repair_request_path('00000666', status: "1", guid: '123456789')
 
-      expect(find_by_id('hackney_repair_request_priority')).to have_content 'N - Normal'
-      expect(find_by_id('hackney_repair_request_description')).to have_content 'CC Electric lighting: Communal; Block Lighting; 3; All lights out'
+      expect(page).to have_select('Task priority', selected: 'N - Normal')
+      expect(page).to have_field('Problem description', with: 'CC Electric lighting: Communal; Block Lighting; 3; All lights out')
 
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
@@ -342,7 +341,7 @@ RSpec.describe 'Repair request' do
       expect(page).to have_css(".hackney-property-warning-label-turquoise")
       click_on 'Raise a repair on this dwelling'
 
-      expect(page).to have_content "CC"
+      expect(page).to have_css('.hackney-cautionary-contact-table')
       expect(page).to have_link("Launch Keyfax", href: "https://www.keyfax.com")
 
       stub_post_bad_repair_request
@@ -356,7 +355,7 @@ RSpec.describe 'Repair request' do
       click_on 'Create works order'
 
       expect(current_path).to be == property_repair_requests_path('00000666')
-      expect(find_by_id('hackney_repair_request_description')).to have_content "CC It's broken"
+      expect(page).to have_field('Problem description', with: "CC It's broken")
     end
   end
 

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Repair request' do
         }],
         "priority": "N",
         "propertyReference": "00000666",
-        "problemDescription": "It's broken",
+        "problemDescription": "CC It's broken",
         "lbhEmail": Helpers::Authentication::EMAIL
       }.to_json
     ).to_return(
@@ -27,7 +27,7 @@ RSpec.describe 'Repair request' do
       body: {
         "repairRequestReference" => "03210303",
         "propertyReference" =>"00000666",
-        "problemDescription" => "It's broken",
+        "problemDescription" => "CC It's broken",
         "priority" => "N",
         "contact" => {
           "name" => "Miss Piggy",
@@ -71,7 +71,7 @@ RSpec.describe 'Repair request' do
         }],
         "priority": "N",
         "propertyReference": "00000666",
-        "problemDescription": "It's broken",
+        "problemDescription": "CC It's broken",
         "lbhEmail": Helpers::Authentication::EMAIL
       }.to_json
     ).to_return(
@@ -300,13 +300,14 @@ RSpec.describe 'Repair request' do
 
       expect(page).to have_content "CC"
       expect(page).to have_link("Launch Keyfax", href: "https://www.keyfax.com")
+      expect(find_by_id('hackney_repair_request_description')).to have_content 'CC'
 
       stub_keyfax_get_results_response
 
       visit new_property_repair_request_path('00000666', status: "1", guid: '123456789')
 
       select "N - Normal"
-      fill_in "Problem description", with: "It's broken"
+      fill_in "Problem description", with: "CC It's broken"
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
 
@@ -347,13 +348,14 @@ RSpec.describe 'Repair request' do
 
       select "N - Normal"
       fill_in "SOR Code", with: "Abcdefg"
-      fill_in "Problem description", with: "It's broken"
+      fill_in "Problem description", with: "CC It's broken"
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
 
       click_on 'Create works order'
 
       expect(current_path).to be == property_repair_requests_path('00000666')
+      expect(find_by_id('hackney_repair_request_description')).to have_content "CC It's broken"
     end
   end
 

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Repair request' do
         }],
         "priority": "N",
         "propertyReference": "00000666",
-        "problemDescription": "CC It's broken",
+        "problemDescription": "CC Electric lighting: Communal; Block Lighting; 3; All lights out",
         "lbhEmail": Helpers::Authentication::EMAIL
       }.to_json
     ).to_return(
@@ -27,7 +27,7 @@ RSpec.describe 'Repair request' do
       body: {
         "repairRequestReference" => "03210303",
         "propertyReference" =>"00000666",
-        "problemDescription" => "CC It's broken",
+        "problemDescription" => "CC Electric lighting: Communal; Block Lighting; 3; All lights out", 
         "priority" => "N",
         "contact" => {
           "name" => "Miss Piggy",
@@ -298,7 +298,7 @@ RSpec.describe 'Repair request' do
       expect(page).to have_css(".hackney-property-warning-label-turquoise")
       click_on 'Raise a repair on this dwelling'
 
-      expect(page).to have_content "CC"
+      page.should have_css('.hackney-cautionary-contact-table')
       expect(page).to have_link("Launch Keyfax", href: "https://www.keyfax.com")
       expect(find_by_id('hackney_repair_request_description')).to have_content 'CC'
 
@@ -306,8 +306,9 @@ RSpec.describe 'Repair request' do
 
       visit new_property_repair_request_path('00000666', status: "1", guid: '123456789')
 
-      select "N - Normal"
-      fill_in "Problem description", with: "CC It's broken"
+      expect(find_by_id('hackney_repair_request_priority')).to have_content 'N - Normal'
+      expect(find_by_id('hackney_repair_request_description')).to have_content 'CC Electric lighting: Communal; Block Lighting; 3; All lights out'
+
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
 


### PR DESCRIPTION
https://trello.com/c/K8VxR3Hq/184-cautionary-contact-info-must-be-manually-copied-into-description-for-it-to-show-in-drs