### PR TITLE
Allow multiple SOR codes.

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -184,7 +184,7 @@ module HackneyAPI
       API_REQUEST_CACHE.delete_matched "*repairs*#{property_reference}*"
     end
 
-    def post_repair_request(name:, phone:, sor_codes:, priority:, property_ref:, description:, created_by_email:)
+    def post_repair_request(name:, phone:, work_orders:, priority:, property_ref:, description:, created_by_email:)
       response = request(
         http_method: :post,
         endpoint: "#{API_VERSION}/repairs",
@@ -194,7 +194,12 @@ module HackneyAPI
             "name": name,
             "telephoneNumber": phone,
           },
-          "workOrders": sor_codes.map {|x| { "sorCode": x } },
+          "workOrders": work_orders.map do |work_order|
+            {
+              "sorCode": work_order.sor_code,
+              "EstimatedUnits": work_order.quantity
+            }
+          end,
           "priority": priority,
           "propertyReference": property_ref,
           "problemDescription": description,

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@ $govuk-breakpoints: (
 @import "hackney_address_list";
 @import "hackney_document";
 @import "hackney_property";
+@import "repair_requests";
 
 .hackney-template {
   min-width: 1024px;
@@ -213,4 +214,13 @@ $govuk-breakpoints: (
 
 .color-secondary {
   color: $govuk-secondary-text-colour;
+}
+
+.button-link {
+  @extend %govuk-link;
+
+  text-decoration: underline;
+  padding: 0;
+  border: none;
+  background-color: inherit;
 }

--- a/app/assets/stylesheets/repair_requests.scss
+++ b/app/assets/stylesheets/repair_requests.scss
@@ -1,0 +1,30 @@
+.repair-request-sor-code-table {
+  th {
+    text-align: left;
+  }
+
+  td {
+    @include govuk-responsive-padding(6, "right");
+    text-align: left;
+    vertical-align: bottom;
+  }
+
+  td.sor-code-column {
+    width: 50%;
+  }
+
+  td.quantity-column {
+    width: 25%;
+  }
+
+  td.keyfax-column {
+    width: 25%;
+    padding: 0;
+    min-width: 165px;
+  }
+
+  /* FIXME: not great */
+  .keyfax-button {
+    margin-bottom: 2px;
+  }
+}

--- a/app/models/hackney/repair_request.rb
+++ b/app/models/hackney/repair_request.rb
@@ -48,7 +48,7 @@ class Hackney::RepairRequest
     response = HackneyAPI::RepairsClient.new.post_repair_request(
       name: contact_name,
       phone: telephone_number,
-      sor_codes: work_orders&.map(&:sor_code) || [],
+      work_orders: work_orders || [],
       priority: priority,
       property_ref: property_reference,
       description: description.squish,
@@ -122,6 +122,8 @@ class Hackney::RepairRequest
       "description"
     when /^\/workOrders\/(\d+)\/sorCode/i
       "work_orders[#{$1.to_i}].sor_code"
+    when /^\/workOrders\/(\d+)\/EstimatedUnits/i
+      "work_orders[#{$1.to_i}].quantity"
     else
       "base"
     end

--- a/app/models/hackney/work_order.rb
+++ b/app/models/hackney/work_order.rb
@@ -6,6 +6,8 @@ class Hackney::WorkOrder
                 :problem_description, :trade, :supplier_reference, :sor_code,
                 :raised_by
 
+  attr_accessor :quantity
+
   def self.find(reference)
     response = HackneyAPI::RepairsClient.new.get_work_order(reference)
     build(response)

--- a/app/views/repair_requests/new.html.erb
+++ b/app/views/repair_requests/new.html.erb
@@ -26,20 +26,48 @@
       ) do |form|
       %>
 
-      <%= form.fields_for :work_orders do |fields| %>
-        <%= fields.form_group :sor_code do %>
-          <%= fields.label :sor_code, "SOR Code" %>
-          <%= fields.error_messages :sor_code %>
-          <div class="govuk-grid-row" style="height: auto">
-            <div class="govuk-grid-column-one-half">
-              <%= fields.text_field :sor_code %>
-            </div>
-            <div class="govuk-grid-column-one-half">
-              <%= link_to "Launch Keyfax", @keyfax_session.launch_url, class: "govuk-button govuk-!-margin-bottom-0" %>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
+        <table class="repair-request-sor-code-table">
+          <%= form.fields_for :work_orders, @repair_request.work_orders.first do |fields| %>
+            <tr>
+              <th>
+                <%= fields.label :sor_code, "SOR Code" %>
+              </th>
+              <th>
+                <%= fields.label :quantity, "Quantity" %>
+              </th>
+              <th>
+              </th>
+            </tr>
+          <% end %>
+
+          <% @repair_request.work_orders.each_with_index do |work_order, i| %>
+            <%= form.fields_for :work_orders, work_order, child_index: i do |fields| %>
+              <tr>
+                <td class="sor-code-column">
+                  <%= fields.form_group :sor_code do %>
+                    <%= fields.error_messages :sor_code %>
+                    <%= fields.text_field :sor_code %>
+                  <% end %>
+                </td>
+                <td class="quantity-column">
+                  <%= fields.form_group :quantity do %>
+                    <%= fields.error_messages :quantity %>
+                    <%= fields.text_field :quantity %>
+                  <% end %>
+                </td>
+                <td class="keyfax-column">
+                  <% if i == 0 %>
+                    <div class="govuk-form-group">
+                      <%= link_to "Launch Keyfax", @keyfax_session.launch_url, class: "govuk-button keyfax-button" %>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% end %>
+        </table>
+
+        <%= form.submit "+ Add another SOR code", name: "add_work_order", class: "button-link govuk-link hackney-link govuk-body-s" %>
 
       <%= form.form_group :priority do %>
         <%= form.label :priority, "Task priority" %>

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -181,7 +181,14 @@ describe HackneyAPI::RepairsClient do
             "telephoneNumber": "01234567890",
           },
           "workOrders": [
-            "sorCode": "08500820",
+            {
+              "sorCode": "08500820",
+              "EstimatedUnits": 1
+            },
+            {
+              "sorCode": "08500820",
+              "EstimatedUnits": 2
+            }
           ],
           "priority": "G",
           "propertyReference": "00000018",
@@ -197,7 +204,10 @@ describe HackneyAPI::RepairsClient do
         api_client.post_repair_request(
           name: "blablabla",
           phone: "01234567890",
-          sor_codes: ["08500820"],
+          work_orders: [
+            Hackney::WorkOrder.new(sor_code: "08500820", quantity: 1),
+            Hackney::WorkOrder.new(sor_code: "08500820", quantity: 2)
+          ],
           priority: "G",
           property_ref: "00000018",
           description: "it's broken fix it",

--- a/spec/controllers/repair_requests_controller_spec.rb
+++ b/spec/controllers/repair_requests_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             },
             "workOrders": [{
               "sorCode": "20110120",
+              "EstimatedUnits": ?1
             }],
             "priority": "E",
             "propertyReference": "00000666",
@@ -88,6 +89,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             },
             work_orders_attributes: [{
               "sor_code": "20110120",
+              "quantity": 1
             }],
             "priority": "E",
             description: "It's broken",
@@ -118,6 +120,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             },
             "workOrders": [{
               "sorCode": "LME5R500",
+              "EstimatedUnits": ?1
             }],
             "priority": "E",
             "propertyReference": "00000666",
@@ -154,6 +157,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             },
             work_orders_attributes: [{
               "sor_code": "LME5R500",
+              "quantity": 1
             }],
             "priority": "E",
             description: "It's broken",

--- a/spec/features/repair_request_spec.rb
+++ b/spec/features/repair_request_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Repair request' do
         },
         "workOrders": [{
           "sorCode": "20110120",
+          "EstimatedUnits": ?1
         }],
         "priority": "N",
         "propertyReference": "00000666",
@@ -68,6 +69,7 @@ RSpec.describe 'Repair request' do
         },
         "workOrders": [{
           "sorCode": "Abcdefg",
+          "EstimatedUnits": "666"
         }],
         "priority": "N",
         "propertyReference": "00000666",
@@ -308,6 +310,7 @@ RSpec.describe 'Repair request' do
       expect(page).to have_select('Task priority', selected: 'N - Normal')
       expect(page).to have_field('Problem description', with: 'CC Electric lighting: Communal; Block Lighting; 3; All lights out')
 
+      fill_in "Quantity", with: 1
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
 
@@ -348,6 +351,7 @@ RSpec.describe 'Repair request' do
 
       select "N - Normal"
       fill_in "SOR Code", with: "Abcdefg"
+      fill_in "Quantity", with: 666
       fill_in "Problem description", with: "CC It's broken"
       fill_in "Caller name", with: "Miss Piggy"
       fill_in "Contact number", with: "01234567890"
@@ -369,4 +373,6 @@ RSpec.describe 'Repair request' do
       expect(page).to have_text("Cannot raise a repair on this property due to tenure type")
     end
   end
+
+  pending 'Multiple SOR Codes'
 end

--- a/spec/models/hackney/repair_request_spec.rb
+++ b/spec/models/hackney/repair_request_spec.rb
@@ -66,7 +66,14 @@ describe Hackney::RepairRequest, '#save' do
           "telephoneNumber": "01234567890",
         },
         "workOrders": [
-          "sorCode": "08500820",
+          {
+            "sorCode": "08500820",
+            "EstimatedUnits": 1,
+          },
+          {
+            "sorCode": "08500820",
+            "EstimatedUnits": 2,
+          }
         ],
         "priority": "G",
         "propertyReference": "00000018",
@@ -89,6 +96,11 @@ describe Hackney::RepairRequest, '#save' do
             "workOrderReference" => "01552718",
             "sorCode" => "08500820",
             "supplierReference" => "H01"
+          },
+          {
+            "workOrderReference" => "01552718",
+            "sorCode" => "08500820",
+            "supplierReference" => "H01"
           }
         ]
       }.to_json
@@ -100,7 +112,14 @@ describe Hackney::RepairRequest, '#save' do
         telephone_number: "01234567890"
       },
       work_orders_attributes: [
-        { sor_code: "08500820" }
+        {
+          sor_code: "08500820",
+          quantity: 1
+        },
+        {
+          sor_code: "08500820",
+          quantity: 2
+        }
       ],
       priority: "G",
       property_reference: "00000018",
@@ -127,8 +146,14 @@ describe Hackney::RepairRequest, '#save' do
           "telephoneNumber": "N/A",
         },
         "workOrders": [
-          { "sorCode": "" },
-          { "sorCode": "" }
+          {
+            "sorCode": "",
+            "EstimatedUnits": ""
+          },
+          {
+            "sorCode": "",
+            "EstimatedUnits": ""
+          }
         ],
         "priority": "G",
         "propertyReference": "00000018",
@@ -158,6 +183,18 @@ describe Hackney::RepairRequest, '#save' do
         },
         {
           "code" => 400,
+          "source" => "/workOrders/0/EstimatedUnits",
+          "developerMessage" => "EstimatedUnits is invalid",
+          "userMessage" => "Bad quantity"
+        },
+        {
+          "code" => 400,
+          "source" => "/workOrders/1/EstimatedUnits",
+          "developerMessage" => "EstimatedUnits is invalid",
+          "userMessage" => "Bad quantity"
+        },
+        {
+          "code" => 400,
           "source" => "/contact/name",
           "developerMessage" => "Contact Name cannot be empty",
           "userMessage" => "Please provide a name for the contact"
@@ -177,8 +214,14 @@ describe Hackney::RepairRequest, '#save' do
         telephone_number: ""
       },
       work_orders_attributes: [
-        { sor_code: "" },
-        { sor_code: "" }
+        {
+          sor_code: "",
+          quantity: ""
+        },
+        {
+          sor_code: "",
+          quantity: ""
+        }
       ],
       priority: "G",
       property_reference: "00000018",
@@ -203,6 +246,12 @@ describe Hackney::RepairRequest, '#save' do
     expect(repair_request.errors.added?("work_orders[1].sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
     expect(repair_request.work_orders[1].errors.added?("sor_code", "If Repair request has workOrders you must provide a valid sorCode")).to be_truthy
 
+    expect(repair_request.errors.added?("work_orders[0].quantity", "Bad quantity")).to be_truthy
+    expect(repair_request.work_orders[0].errors.added?("quantity", "Bad quantity")).to be_truthy
+
+    expect(repair_request.errors.added?("work_orders[1].quantity", "Bad quantity")).to be_truthy
+    expect(repair_request.work_orders[1].errors.added?("quantity", "Bad quantity")).to be_truthy
+
     expect(repair_request.errors.added?("description", "Please provide a valid Problem")).to be_truthy
   end
 
@@ -217,7 +266,10 @@ describe Hackney::RepairRequest, '#save' do
           "telephoneNumber": "01234567890",
         },
         "workOrders": [
-          "sorCode": "08500820",
+          {
+            "sorCode": "08500820",
+            "EstimatedUnits": 1
+          }
         ],
         "priority": "G",
         "propertyReference": "00000018",
@@ -251,7 +303,10 @@ describe Hackney::RepairRequest, '#save' do
         telephone_number: "01234567890"
       },
       work_orders_attributes: [
-        { sor_code: "08500820" }
+        {
+          sor_code: "08500820",
+          quantity: 1
+        }
       ],
       priority: "G",
       property_reference: "00000018",


### PR DESCRIPTION
Trello:
https://trello.com/c/NOFdykvv/170-enable-adding-multiple-sor-codes-in-a-single-works-order-eg-for-leaks-hub-surveyors-without-keyfax