### PR TITLE
Recharge

### DIFF
--- a/app/apis/hackney_api/repairs_client.rb
+++ b/app/apis/hackney_api/repairs_client.rb
@@ -191,7 +191,7 @@ module HackneyAPI
       API_REQUEST_CACHE.delete_matched "*repairs*#{property_reference}*"
     end
 
-    def post_repair_request(name:, phone:, tasks:, priority:, property_ref:, description:, created_by_email:)
+    def post_repair_request(name:, phone:, tasks:, priority:, property_ref:, description:, recharge:, created_by_email:)
       response = request(
         http_method: :post,
         endpoint: "#{API_VERSION}/repairs",
@@ -211,6 +211,7 @@ module HackneyAPI
           "priority": priority,
           "propertyReference": property_ref,
           "problemDescription": description,
+          "isRecharge": recharge,
           "lbhEmail": created_by_email
         }.to_json
       )

--- a/app/controllers/repair_requests_controller.rb
+++ b/app/controllers/repair_requests_controller.rb
@@ -124,7 +124,8 @@ class RepairRequestsController < ApplicationController
           ]
         },
         :priority,
-        :description
+        :description,
+        :recharge
     ])
   end
 end

--- a/app/helpers/govuk_form_helper.rb
+++ b/app/helpers/govuk_form_helper.rb
@@ -20,7 +20,8 @@ module GovukFormHelper
 
     def label(*args)
       options = args.extract_options!
-      args << options.merge(class: "govuk-label")
+      options[:class] = "govuk-label " + options[:class].to_s
+      args << options
       super
     end
 
@@ -43,11 +44,33 @@ module GovukFormHelper
       super
     end
 
+    def checkboxes_group(&b)
+      @template.content_tag(class: "govuk-checkboxes") do
+        yield if block_given?
+      end.html_safe
+    end
+
+    def checkboxes_group_item(&b)
+      @template.content_tag(class: "govuk-checkboxes__item") do
+        yield if block_given?
+      end.html_safe
+    end
+
+    def check_box(method, options = {}, *args)
+      class_and_error_wrap(method, "govuk-checkboxes__input", "", options)
+      super
+    end
+
+    def check_box_label(method, text = nil, options = {}, *args)
+      class_and_error_wrap(method, "govuk-checkboxes__label", "", options)
+      label(method, text, options, *args)
+    end
+
     private
 
     def class_and_error_wrap(method, clazz, error_clazz, options)
       options[:class] ||= clazz
-      options[:class] += " " + error_clazz if object.errors.include?(method)
+      options[:class] += " " + error_clazz.to_s if object.errors.include?(method)
       options
     end
   end

--- a/app/helpers/govuk_form_helper.rb
+++ b/app/helpers/govuk_form_helper.rb
@@ -20,7 +20,7 @@ module GovukFormHelper
 
     def label(*args)
       options = args.extract_options!
-      options[:class] = "govuk-label " + options[:class].to_s
+      options[:class] = "govuk-label " + options.fetch(:class, "")
       args << options
       super
     end

--- a/app/views/repair_requests/new.html.erb
+++ b/app/views/repair_requests/new.html.erb
@@ -90,6 +90,16 @@
         </span>
       <% end %>
 
+      <%= form.form_group :recharge do %>
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= form.error_messages :recharge %>
+            <%= form.check_box :recharge %>
+            <%= form.check_box_label :recharge, "Recharge repair to tenant" %>
+          </div>
+        </div>
+      <% end %>
+
       <%= form.fields_for :contact do |fields| %>
         <%= fields.form_group :name do %>
           <%= fields.label :name, "Caller name" %>

--- a/spec/apis/hackney_api/repairs_client_spec.rb
+++ b/spec/apis/hackney_api/repairs_client_spec.rb
@@ -193,6 +193,7 @@ describe HackneyAPI::RepairsClient do
           "priority": "G",
           "propertyReference": "00000018",
           "problemDescription": "it's broken fix it",
+          "isRecharge": true,
           "lbhEmail": "pudding@hackney.gov.uk"
         }.to_json
       ).to_return(status: 200, body: '{"works": true }')
@@ -211,6 +212,7 @@ describe HackneyAPI::RepairsClient do
           priority: "G",
           property_ref: "00000018",
           description: "it's broken fix it",
+          recharge: true,
           created_by_email: "pudding@hackney.gov.uk"
         )
       ).to be == {"works" => true}

--- a/spec/controllers/repair_requests_controller_spec.rb
+++ b/spec/controllers/repair_requests_controller_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             "priority": "E",
             "propertyReference": "00000666",
             "problemDescription": "It's broken",
+            "isRecharge": true,
             "lbhEmail": "agent.piggy@hackney.gov.uk"
           }.to_json
         ).to_return(
@@ -113,6 +114,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             }],
             "priority": "E",
             description: "It's broken",
+            recharge: "1",
           }
         }
 
@@ -145,6 +147,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             "priority": "E",
             "propertyReference": "00000666",
             "problemDescription": "It's broken",
+            "isRecharge": true,
             "lbhEmail": "agent.piggy@hackney.gov.uk"
           }.to_json
         ).to_return(
@@ -181,6 +184,7 @@ RSpec.describe RepairRequestsController, type: :controller do
             }],
             "priority": "E",
             description: "It's broken",
+            "recharge": "1",
           }
         }
 

--- a/spec/models/hackney/repair_request_spec.rb
+++ b/spec/models/hackney/repair_request_spec.rb
@@ -78,6 +78,7 @@ describe Hackney::RepairRequest, '#save' do
         "priority": "G",
         "propertyReference": "00000018",
         "problemDescription": "it's broken fix it",
+        "isRecharge": true,
         "lbhEmail": "pudding@hackney.gov.uk"
       }.to_json
     ).to_return(
@@ -124,6 +125,7 @@ describe Hackney::RepairRequest, '#save' do
       priority: "G",
       property_reference: "00000018",
       description: "it's broken fix it",
+      recharge: true,
       created_by_email: "pudding@hackney.gov.uk"
     )
 
@@ -158,6 +160,7 @@ describe Hackney::RepairRequest, '#save' do
         "priority": "G",
         "propertyReference": "00000018",
         "problemDescription": "",
+        "isRecharge": true,
         "lbhEmail": "pudding@hackney.gov.uk"
       }.to_json
     ).to_return(
@@ -204,7 +207,13 @@ describe Hackney::RepairRequest, '#save' do
           "source" => "/contact/telephoneNumber",
           "developerMessage" => "Contact Telephone number is invalid",
           "userMessage" => "Telephone number must contain minimum of 10 and maximum of 11 digits"
-        }
+        },
+        {
+          "code" => 400,
+          "source" => "/isRecharge",
+          "developerMessage" => "Developers",
+          "userMessage" => "Bad recharge"
+        },
       ].to_json
     )
 
@@ -226,6 +235,7 @@ describe Hackney::RepairRequest, '#save' do
       priority: "G",
       property_reference: "00000018",
       description: "",
+      recharge: true,
       created_by_email: "pudding@hackney.gov.uk"
     )
 
@@ -253,6 +263,7 @@ describe Hackney::RepairRequest, '#save' do
     expect(repair_request.tasks[1].errors.added?("estimated_units", "Bad estimated_units")).to be_truthy
 
     expect(repair_request.errors.added?("description", "Please provide a valid Problem")).to be_truthy
+    expect(repair_request.errors.added?("recharge", "Bad recharge")).to be_truthy
   end
 
   it "removes extra whitespace from description" do
@@ -274,6 +285,7 @@ describe Hackney::RepairRequest, '#save' do
         "priority": "G",
         "propertyReference": "00000018",
         "problemDescription": "it's broken fix it please",
+        "isRecharge": true,
         "lbhEmail": "pudding@hackney.gov.uk"
       }.to_json
     ).to_return(
@@ -311,6 +323,7 @@ describe Hackney::RepairRequest, '#save' do
       priority: "G",
       property_reference: "00000018",
       description: "  it's broken   \n\n      fix it please  \n   ",
+      recharge: true,
       created_by_email: "pudding@hackney.gov.uk"
     )
 


### PR DESCRIPTION
Trello:
https://trello.com/c/8tc216xn/218-as-an-rcc-agent-i-need-to-mark-a-new-repair-as-recharge-so-that-it-gets-invoiced-properly

When the job falls under 'recharge' policy, an RCC agent should be able to indicate that easily on the new repair form. This is possible by adding a `RECHARGE` SOR code to the work order.

It would be best to implement this as a separate tickbox rather than as part of the multi-sor code process so that it will be clearer for agents. The backend would then process this tickbox to add the RECHARGE code to the SOR list.

Ideally the logic should be done in the API, but up for discussion.

---
Note that the RECHARGE code does not work in the DEV environment as it has not been added to UH there. But it should already work in LIVE.